### PR TITLE
more than the branch title...

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -1,10 +1,149 @@
 #include <bind.h>
+#include <context.h>
 
 namespace gjs {
+	type_manager::type_manager(vm_context* ctx) : m_ctx(ctx) {
+	}
+
+	type_manager::~type_manager() {
+	}
+
+	vm_type* type_manager::get(const std::string& name) {
+		if (m_types.count(name) == 0) return nullptr;
+		return m_types[name];
+	}
+
+	vm_type* type_manager::add(const std::string& name, const std::string& internal_name) {
+		if (m_types.count(internal_name) > 0) {
+			throw bind_exception(format("Type '%s' already bound", name.c_str()));
+		}
+		vm_type* t = new vm_type();
+		t->name = name;
+		t->internal_name = internal_name;
+
+		m_types[internal_name] = t;
+
+		return t;
+	}
+
+	void type_manager::finalize_class(bind::wrapped_class* wrapped) {
+		auto it = m_types.find(wrapped->internal_name);
+		if (it == m_types.end()) {
+			throw bind_exception(format("Type '%s' not found and can not be finalized", wrapped->name.c_str()));
+		}
+
+		vm_type* t = it->getSecond();
+
+		t->size = wrapped->size;
+		t->constructor = wrapped->ctor ? new vm_function(this, wrapped->ctor) : nullptr;
+		t->destructor = wrapped->dtor ? new vm_function(this, wrapped->dtor) : nullptr;
+
+		for (auto i = wrapped->properties.begin();i != wrapped->properties.end();++i) {
+			t->properties.push_back({
+				i->getFirst(),
+				get(i->getSecond()->type.name()),
+				i->getSecond()->offset
+			});
+		}
+
+		for (auto i = wrapped->methods.begin();i != wrapped->methods.end();++i) {
+			t->methods.push_back(new vm_function(this, i->getSecond()));
+		}
+	}
+
+	std::vector<vm_type*> type_manager::all() {
+		std::vector<vm_type*> out;
+		for (auto i = m_types.begin();i != m_types.end();++i) {
+			out.push_back(i->getSecond());
+		}
+		return out;
+	}
+
+	vm_function::vm_function(const std::string _name, address addr) {
+		name = _name;
+		access.entry = addr;
+		is_host = false;
+		signature.return_loc = vm_register::v0;
+	}
+	vm_function::vm_function(type_manager* mgr, bind::wrapped_function* wrapped) {
+		name = wrapped->name;
+		signature.text = wrapped->sig;
+		for (u8 i = 0;i < wrapped->arg_types.size();i++) {
+			signature.arg_types.push_back(mgr->get(wrapped->arg_types[i].name()));
+			if (!signature.arg_types[i]) {
+				throw bind_exception(format("Arg '%d' of function '%s' is of type '%s' that has not been bound yet", i + 1, name.c_str(), wrapped->arg_types[i].name()));
+			}
+
+			vm_register last_a = vm_register(integer(vm_register::a0) - 1);
+			vm_register last_f = vm_register(integer(vm_register::f0) - 1);
+
+			for (u8 a = 0;a < signature.arg_locs.size();a++) {
+				vm_register l = signature.arg_locs[a];
+				if (l >= vm_register::a0 && l <= vm_register::a7) last_a = l;
+				else last_f = l;
+			}
+
+			if (std::string(wrapped->arg_types[i].name()) == "float") signature.arg_locs.push_back(vm_register(integer(last_f) + 1));
+			else signature.arg_locs.push_back(vm_register(integer(last_a) + 1));
+		}
+
+		signature.return_type = mgr->get(wrapped->return_type.name());
+		if (!signature.return_type) {
+			throw bind_exception(format("Return value of function '%s' is of type '%s' that has not been bound yet", name.c_str(), wrapped->return_type.name()));
+		}
+
+		signature.is_thiscall = wrapped->name.find_first_of(':') != std::string::npos;
+		signature.return_loc = vm_register::v0;
+		access.wrapped = wrapped;
+		mgr->m_ctx->add(this);
+	}
+
+	void vm_function::arg(vm_type* type) {
+		if (is_host) throw bind_exception("Cannot specify arguments for host functions");
+		if (!type) throw bind_exception("No type specified for argument");
+		signature.arg_types.push_back(type);
+		vm_register last_a = vm_register(integer(vm_register::a0) - 1);
+		vm_register last_f = vm_register(integer(vm_register::f0) - 1);
+
+		for (u8 a = 0;a < signature.arg_locs.size();a++) {
+			vm_register l = signature.arg_locs[a];
+			if (l >= vm_register::a0 && l <= vm_register::a7) last_a = l;
+			else last_f = l;
+		}
+
+		if (type->name == "decimal") signature.arg_locs.push_back(vm_register(integer(last_f) + 1));
+		else signature.arg_locs.push_back(vm_register(integer(last_a) + 1));
+	}
+
+	vm_type::vm_type() {
+		constructor = nullptr;
+		destructor = nullptr;
+		size = 0;
+		is_primitive = false;
+	}
+
 	namespace bind {
 		std::any& get_input_param(std::vector<std::any>& params, u32 idx) {
 			return params[idx];
 		}
 
+		void set_arguments(script_function* func, u8 idx) {
+		}
+
+		declare_input_binding(integer, context, in, reg_ptr) {
+			(*(integer*)reg_ptr) = in;
+		}
+
+		declare_output_binding(integer, context, out, reg_ptr) {
+			*out = *(integer*)reg_ptr;
+		}
+
+		declare_input_binding(decimal, context, in, reg_ptr) {
+			(*(decimal*)reg_ptr) = in;
+		}
+
+		declare_output_binding(decimal, context, out, reg_ptr) {
+			*out = *(decimal*)reg_ptr;
+		}
 	};
 };

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -127,6 +127,9 @@ namespace gjs {
 		destructor = nullptr;
 		size = 0;
 		is_primitive = false;
+		is_floating_point = false;
+		is_unsigned = false;
+		is_builtin = false;
 		m_wrapped = nullptr;
 	}
 

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -40,9 +40,12 @@ namespace gjs {
 
 		for (auto i = wrapped->properties.begin();i != wrapped->properties.end();++i) {
 			t->properties.push_back({
+				i->getSecond()->flags,
 				i->getFirst(),
 				get(i->getSecond()->type.name()),
-				i->getSecond()->offset
+				i->getSecond()->offset,
+				i->getSecond()->getter ? new vm_function(this, i->getSecond()->getter) : nullptr,
+				i->getSecond()->setter ? new vm_function(this, i->getSecond()->setter) : nullptr
 			});
 		}
 

--- a/src/bind.h
+++ b/src/bind.h
@@ -479,6 +479,9 @@ namespace gjs {
 			std::string internal_name;
 			u32 size;
 			bool is_primitive;
+			bool is_unsigned;
+			bool is_floating_point;
+			bool is_builtin;
 
 			struct property {
 				u8 flags;

--- a/src/bind.h
+++ b/src/bind.h
@@ -254,7 +254,7 @@ namespace gjs {
 						if (!tpm->get<Ret>()) {
 							throw bind_exception(format("Return type '%s' of method '%s' of class '%s' has not been bound yet", base_type_name<Ret>(), name.c_str(), typeid(remove_all<Cls>::type).name()));
 						}
-						address = u64(reinterpret_cast<void*>(f));
+						address = u64(reinterpret_cast<void*>(&f));
 
 						asmjit::CodeHolder h;
 						h.init(rt.codeInfo());
@@ -351,7 +351,8 @@ namespace gjs {
 		enum property_flags {
 			pf_none				= 0b00000000,
 			pf_read_only		= 0b00000001,
-			pf_write_only		= 0b00000010
+			pf_write_only		= 0b00000010,
+			pf_object_pointer	= 0b00000100
 		};
 
 		struct wrapped_class {
@@ -524,9 +525,12 @@ namespace gjs {
 			bool is_primitive;
 
 			struct property {
+				u8 flags;
 				std::string name;
 				vm_type* type;
 				u32 offset;
+				vm_function* getter;
+				vm_function* setter;
 			};
 
 			enum class operator_func {

--- a/src/bind.h
+++ b/src/bind.h
@@ -10,8 +10,69 @@
 #include <types.h>
 #include <robin_hood.h>
 
+#define declare_input_binding(type, ctx_name, in_name, reg_name) template<> void to_reg<type>(vm_context* ctx_name, const type& in_name, u64* reg_name)
+#define declare_output_binding(type, ctx_name, out_name, reg_name) template<> void from_reg<type>(vm_context* ctx_name, type* out_name, u64* reg_name)
+
 #define fimm(f) asmjit::imm(reinterpret_cast<void*>(f))
 namespace gjs {
+	class vm_context;
+	enum class vm_register;
+	class vm_function;
+	class vm_type;
+
+	class bind_exception : public std::exception {
+		public:
+			bind_exception(const std::string& _text) : text(_text) { }
+			~bind_exception() { }
+
+			virtual char const* what() const { return text.c_str(); }
+
+			std::string text;
+	};
+
+	namespace bind {
+		struct wrapped_class;
+	};
+
+
+	template<class T> struct remove_all { typedef T type; };
+	template<class T> struct remove_all<T*> : remove_all<T> {};
+	template<class T> struct remove_all<T&> : remove_all<T> {};
+	template<class T> struct remove_all<T&&> : remove_all<T> {};
+	template<class T> struct remove_all<T const> : remove_all<T> {};
+	template<class T> struct remove_all<T volatile> : remove_all<T> {};
+	template<class T> struct remove_all<T const volatile> : remove_all<T> {};
+	template<class T> struct remove_all<T[]> : remove_all<T> {};
+
+	template <typename T>
+	inline const char* base_type_name() {
+		return typeid(remove_all<T>::type).name();
+	}
+
+	class type_manager {
+		public:
+			type_manager(vm_context* ctx);
+			~type_manager();
+
+			vm_type* get(const std::string& internal_name);
+
+			template <typename T>
+			vm_type* get() {
+				return get(base_type_name<T>());
+			}
+
+			vm_type* add(const std::string& name, const std::string& internal_name);
+
+			void finalize_class(bind::wrapped_class* wrapped);
+
+			std::vector<vm_type*> all();
+
+		protected:
+			friend class vm_function;
+			vm_context* m_ctx;
+			robin_hood::unordered_map<std::string, vm_type*> m_types;
+	};
+
 	namespace bind {
 		using arg_arr = std::vector<std::any>;
 
@@ -43,21 +104,29 @@ namespace gjs {
 		using index_range = typename range_builder<MIN, MAX>::type;
 
 		struct wrapped_function {
-			wrapped_function(std::type_index ret, std::vector<std::type_index> args) : return_type(ret), arg_types(args) { }
+			wrapped_function(std::type_index ret, std::vector<std::type_index> args, const std::string& _name, const std::string& _sig)
+			: return_type(ret), arg_types(args), name(_name), sig(_sig) { }
 
 			// class methods must receive /this/ pointer as first argument
 			virtual std::any call(const arg_arr& args) = 0;
 			
+			std::string name;
+			std::string sig;
 			std::type_index return_type;
 			std::vector<std::type_index> arg_types;
+			u64 address;
 		};
 
-		namespace x86 {
+		namespace x86  {
 			using compiler = asmjit::x86::Compiler;
 			using reg = asmjit::x86::Gp;
 
 			template <typename param_type>
-			u8 compile_get_parameter(compiler& c, reg& arg_vec, reg* out_params, size_t pidx) {
+			u8 compile_get_parameter(type_manager* tpm, const std::string& fname, compiler& c, reg& arg_vec, reg* out_params, size_t pidx) {
+				if (!tpm->get<param_type>()) {
+					throw bind_exception(format("Return type '%s' of function '%s' has not been bound yet", base_type_name<param_type>(), fname.c_str()));
+				}
+
 				reg cur_param = c.newGp(asmjit::Type::IdOfT<std::any&>::kTypeId);
 
 				// cur_param = get_input_param(arg_vec, pidx)
@@ -82,11 +151,13 @@ namespace gjs {
 			// Build ASM code to translate vector<std::any> into the actual parameters
 			// for a function call
 			template <typename... Args, size_t... Indices>
-			void compile_get_parameters(compiler& c, reg& in_args, reg* out_params, index_list<Indices...>) {
+			void compile_get_parameters(type_manager* tpm, const std::string& fname, compiler& c, reg& in_args, reg* out_params, index_list<Indices...>) {
 				// Trick the compiler into calling compile_get_parameter for each argument type/index,
 				// passing the type and index to the function
 				std::vector<u8> dummy = {
 					compile_get_parameter<Args>(
+						tpm,
+						fname,
 						c,
 						in_args,
 						out_params,
@@ -116,7 +187,12 @@ namespace gjs {
 				typedef Ret (*func_type)(Args...);
 				typedef std::tuple_size<std::tuple<Args...>> arg_count;
 
-				global_function(asmjit::JitRuntime& rt, func_type f) : wrapped_function(typeid(Ret), { typeid(Args)... }), original_func(f) {
+				global_function(type_manager* tpm, asmjit::JitRuntime& rt, func_type f, const std::string& name) : wrapped_function(typeid(remove_all<Ret>::type), { typeid(remove_all<Args>::type)... }, name, typeid(f).name()), original_func(f) {
+					if (!tpm->get<Ret>()) {
+						throw bind_exception(format("Return type '%s' of function '%s' has not been bound yet", base_type_name<Ret>(), name.c_str()));
+					}
+					address = u64(reinterpret_cast<void*>(f));
+					
 					asmjit::CodeHolder h;
 					h.init(rt.codeInfo());
 					compiler c(&h);
@@ -125,7 +201,7 @@ namespace gjs {
 					c.setArg(0, in_args);
 
 					std::vector<reg> params = { c.newGp(asmjit::Type::IdOfT<Args>::kTypeId)... };
-					compile_get_parameters<Args...>(c, in_args, params.data(), index_range<0, sizeof...(Args)>());
+					compile_get_parameters<Args...>(tpm, name, c, in_args, params.data(), index_range<0, sizeof...(Args)>());
 
 					if (std::is_void<Ret>::value) {
 						auto fcall = c.call(fimm(f), asmjit::FuncSignatureT<Ret, Args...>(asmjit::CallConv::kIdHost));
@@ -171,7 +247,15 @@ namespace gjs {
 					typedef Ret (*func_type)(method_type, Cls*, Args...);
 					typedef std::tuple_size<std::tuple<Args...>> ac;
 
-					class_method(asmjit::JitRuntime& rt, method_type f) : wrapped_function(typeid(Ret), { typeid(Args)... }), original_func(call_class_method<Ret, Cls, Args...>) {
+					class_method(type_manager* tpm, asmjit::JitRuntime& rt, method_type f, const std::string& name) : wrapped_function(typeid(remove_all<Ret>::type), { typeid(remove_all<Args>::type)... }, name, typeid(f).name()), original_func(call_class_method<Ret, Cls, Args...>) {
+						if (!tpm->get<Cls>()) {
+							throw bind_exception(format("Binding method '%s' of class '%s' that has not been bound yet", name.c_str(), typeid(remove_all<Cls>::type).name()));
+						}
+						if (!tpm->get<Ret>()) {
+							throw bind_exception(format("Return type '%s' of method '%s' of class '%s' has not been bound yet", base_type_name<Ret>(), name.c_str(), typeid(remove_all<Cls>::type).name()));
+						}
+						address = u64(reinterpret_cast<void*>(f));
+
 						asmjit::CodeHolder h;
 						h.init(rt.codeInfo());
 						compiler c(&h);
@@ -191,7 +275,7 @@ namespace gjs {
 
 						std::vector<reg> params = { c.newGp(asmjit::Type::IdOfT<Args>::kTypeId)... };
 						params.insert(params.begin(), c.newGp(asmjit::Type::IdOfT<Cls*>::kTypeId));
-						compile_get_parameters<Cls*, Args...>(c, in_args, params.data(), index_range<0, sizeof...(Args) + 1>());
+						compile_get_parameters<Cls*, Args...>(tpm, name, c, in_args, params.data(), index_range<0, sizeof...(Args) + 1>());
 			
 						if (std::is_void<Ret>::value) {
 							auto call = c.call(asmjit::imm(original_func), fs);
@@ -235,13 +319,13 @@ namespace gjs {
 		};
 
 		template <typename Ret, typename... Args>
-		wrapped_function* wrap(asmjit::JitRuntime& rt, Ret(*func)(Args...)) {
-			return new x86::global_function<Ret, Args...>(rt, func);
+		wrapped_function* wrap(type_manager* tpm, asmjit::JitRuntime& rt, const std::string& name, Ret(*func)(Args...)) {
+			return new x86::global_function<Ret, Args...>(tpm, rt, func, name);
 		};
 
 		template <typename Ret, typename Cls, typename... Args>
-		wrapped_function* wrap(asmjit::JitRuntime& rt, Ret(Cls::*func)(Args...)) {
-			return new x86::class_method<Ret, Cls, Args...>(rt, func);
+		wrapped_function* wrap(type_manager* tpm, asmjit::JitRuntime& rt, const std::string& name, Ret(Cls::*func)(Args...)) {
+			return new x86::class_method<Ret, Cls, Args...>(tpm, rt, func, name);
 		};
 
 		template <typename Cls, typename... Args>
@@ -255,15 +339,14 @@ namespace gjs {
 		}
 
 		template <typename Cls, typename... Args>
-		wrapped_function* wrap_constructor(asmjit::JitRuntime& rt) {
-			return wrap(rt, construct_object<Cls, Args...>);
+		wrapped_function* wrap_constructor(type_manager* tpm, asmjit::JitRuntime& rt) {
+			return wrap(tpm, rt, format("%s::construct", typeid(remove_all<Cls>::type).name()), construct_object<Cls, Args...>);
 		}
 
 		template <typename Cls>
-		wrapped_function* wrap_destructor(asmjit::JitRuntime& rt) {
-			return wrap(rt, destruct_object<Cls>);
+		wrapped_function* wrap_destructor(type_manager* tpm, asmjit::JitRuntime& rt) {
+			return wrap(tpm, rt, format("%s::destruct", typeid(remove_all<Cls>::type).name()), destruct_object<Cls>);
 		}
-
 
 		enum property_flags {
 			pf_none				= 0b00000000,
@@ -283,59 +366,188 @@ namespace gjs {
 				u8 flags;
 			};
 
-			wrapped_class(asmjit::JitRuntime& _rt) : rt(_rt) { }
+			wrapped_class(asmjit::JitRuntime& _rt, const std::string& _name, const std::string& _internal_name, size_t _size) :
+				rt(_rt), name(_name), internal_name(_internal_name), size(_size), ctor(nullptr), dtor(nullptr)
+			{
+			}
 
 			asmjit::JitRuntime& rt;
-			std::vector<wrapped_function*> constructors;
+			std::string name;
+			std::string internal_name;
+			wrapped_function* ctor;
 			robin_hood::unordered_map<std::string, wrapped_function*> methods;
 			robin_hood::unordered_map<std::string, property*> properties;
-			wrapped_function* destructor;
+			wrapped_function* dtor;
+			size_t size;
 		};
 
 		template <typename Cls>
 		struct wrap_class : wrapped_class {
-			wrap_class(asmjit::JitRuntime& _rt) : wrapped_class(_rt) { }
+			wrap_class(type_manager* tpm, asmjit::JitRuntime& _rt, const std::string& name) : wrapped_class(_rt, name, typeid(remove_all<Cls>::type).name(), sizeof(remove_all<Cls>::type)), types(tpm) {
+				tpm->add(name, typeid(remove_all<Cls>::type).name());
+			}
 
 			template <typename... Args>
 			wrap_class& constructor() {
-				constructors.push_back(wrap_constructor<Cls, Args...>(rt));
-				if (!destructor) destructor = wrap_destructor<Cls>(rt);
+				ctor = wrap_constructor<Cls, Args...>(types, rt);
+				if (!dtor) dtor = wrap_destructor<Cls>(types, rt);
 				return *this;
 			}
 
 			template <typename Ret, typename... Args>
-			wrap_class& method(const std::string& name, Ret(Cls::*func)(Args...)) {
-				methods[name] = wrap(rt, func);
+			wrap_class& method(const std::string& _name, Ret(Cls::*func)(Args...)) {
+				methods[_name] = wrap(types, rt, name + "::" + _name, func);
 				return *this;
 			}
 
 			template <typename T>
-			wrap_class& prop(const std::string& name, T Cls::*member, u8 flags = property_flags::pf_none) {
-				if (properties.find(name) != properties.end()) {
-					// exception
-					return *this;
+			wrap_class& prop(const std::string& _name, T Cls::*member, u8 flags = property_flags::pf_none) {
+				if (properties.find(_name) != properties.end()) {
+					throw bind_exception(format("Property '%s' already bound to type '%s'", _name.c_str(), name.c_str()));
 				}
+
+				if (!types->get<T>()) {
+					throw bind_exception(format("Attempting to bind property of type '%s' that has not been bound itself", typeid(remove_all<T>::type).name()));
+				}
+
 				u32 offset = (u8*)&((Cls*)nullptr->*member) - (u8*)nullptr;
-				properties[name] = new property(nullptr, nullptr, typeid(T), offset, flags);
+				properties[_name] = new property(nullptr, nullptr, typeid(remove_all<T>::type), offset, flags);
 				return *this;
 			}
 
 			template <typename T>
-			wrap_class& prop(const std::string& name, T(Cls::*getter)(), T(Cls::*setter)(T) = nullptr, u8 flags = property_flags::pf_none) {
-				if (properties.find(name) != properties.end()) {
-					// exception
-					return *this;
+			wrap_class& prop(const std::string& _name, T(Cls::*getter)(), T(Cls::*setter)(T) = nullptr, u8 flags = property_flags::pf_none) {
+				if (properties.find(_name) != properties.end()) {
+					throw bind_exception(format("Property '%s' already bound to type '%s'", _name.c_str(), name.c_str()));
 				}
-				properties[name] = new property(
-					wrap(rt, getter),
-					setter ? wrap(rt, setter) : nullptr,
-					typeid(T),
+
+				if (!types->get<T>()) {
+					throw bind_exception(format("Attempting to bind property of type '%s' that has not been bound itself", typeid(remove_all<T>::type).name()));
+				}
+
+				properties[_name] = new property(
+					wrap(rt, name + "::get_" + _name, getter),
+					setter ? wrap(rt, name + "::set_" + _name, setter) : nullptr,
+					typeid(remove_all<T>::type),
 					0,
 					flags
 				);
 				return *this;
 			}
+
+			void finalize() {
+				types->finalize_class(this);
+			}
+
+			type_manager* types;
 		};
+
+		enum class value_type {
+			integer,
+			decimal,
+			string,
+			object
+		};
+
+		struct script_function {
+			std::string name;
+			vm_context* ctx;
+			address entry;
+			value_type ret_type;
+			vm_register ret_location;
+			std::vector<value_type> arg_types;
+			std::vector<vm_register> arg_locs;
+
+			template <typename T, typename... Args>
+			void call(T* result, Args... args);
+		};
+
+
+		template <typename T>
+		void to_reg(vm_context* context, const T& in, u64* reg_ptr);
+
+		template <typename T>
+		void from_reg(vm_context* context, T* out, u64* reg_ptr);
+
+		template <typename T>
+		void set_argument(script_function* func, u8 idx, const T& arg) {
+			vm_state* state = func->ctx->state();
+			to_reg(func->ctx, arg, &state->registers[(integer)func->arg_locs[idx]]);
+		}
+
+		declare_input_binding(integer, context, in, reg_ptr);
+		declare_output_binding(integer, context, out, reg_ptr);
+		declare_input_binding(decimal, context, in, reg_ptr);
+		declare_output_binding(decimal, context, out, reg_ptr);
+
+		template <typename Arg, typename... Args>
+		void set_arguments(script_function* func, u8 idx, const Arg& a, Args... rest) {
+			set_argument(func, idx, a);
+
+			if (sizeof...(rest) == 0) return;
+			set_arguments(func, idx + 1, rest...);
+		}
+		void set_arguments(script_function* func, u8 idx);
+	};
+
+	class vm_function {
+		public:
+			vm_function(const std::string name, address addr);
+			vm_function(type_manager* mgr, bind::wrapped_function* wrapped);
+
+			void arg(vm_type* type);
+
+			std::string name;
+			bool is_host;
+
+			struct {
+				std::string text;
+				vm_type* return_type;
+				vm_register return_loc;
+				std::vector<vm_type*> arg_types;
+				std::vector<vm_register> arg_locs;
+				bool is_thiscall;
+
+			} signature;
+
+			union {
+				bind::wrapped_function* wrapped;
+				address entry;
+			} access;
+	};
+
+	class vm_type {
+		public:
+			std::string name;
+			std::string internal_name;
+			u32 size;
+			bool is_primitive;
+
+			struct property {
+				std::string name;
+				vm_type* type;
+				u32 offset;
+			};
+
+			enum class operator_func {
+				add,
+				sub,
+				mul,
+				div,
+				eq
+				// ...
+			};
+
+			std::vector<property> properties;
+			vm_function* constructor;
+			vm_function* destructor;
+			std::vector<vm_function*> methods;
+			robin_hood::unordered_map<operator_func, vm_function*> operators;
+			robin_hood::unordered_map<vm_type*, vm_function*> converters;
+
+		protected:
+			friend class type_manager;
+			vm_type();
 	};
 };
 #undef fimm

--- a/src/compile.h
+++ b/src/compile.h
@@ -5,6 +5,7 @@
 
 namespace gjs {
 	class vm_context;
+	class source_map;
 	class instruction_array;
 	struct ast_node;
 
@@ -45,5 +46,5 @@ namespace gjs {
 			u32 col;
 	};
 
-	void compile_ast(vm_context* ctx, ast_node* tree, instruction_array* out);
+	void compile_ast(vm_context* ctx, ast_node* tree, instruction_array* out, source_map* map);
 };

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,44 +1,197 @@
 #include <context.h>
 #include <bind.h>
+#include <parse.h>
+#include <compile.h>
+#include <asmjit/asmjit.h>
 
 namespace gjs {
-	vm_context::vm_context(vm_allocator* alloc, u32 stack_size, u32 mem_size) : m_vm(alloc, stack_size, mem_size), m_instructions(alloc) {
+	runtime_exception::runtime_exception(vm_context* ctx, const std::string& _text) : text(_text), raised_from_script(true), line(0), col(0) {
+		if (ctx->is_executing()) {
+			source_map::src_info info = ctx->map()->get((address)ctx->state()->registers[(integer)vm_register::ip]);
+			file = info.file;
+			lineText = info.lineText;
+			line = info.line;
+			col = info.col;
+		}
+		else raised_from_script = false;
 	}
+
+	runtime_exception::runtime_exception(const std::string& _text) : text(_text), raised_from_script(false), line(0), col(0) {
+	}
+
+	runtime_exception::~runtime_exception() {
+	}
+
+
+
+	vm_context::vm_context(vm_allocator* alloc, u32 stack_size, u32 mem_size) : 
+		m_vm(this, alloc, stack_size, mem_size), m_instructions(alloc), m_is_executing(false),
+		m_catch_exceptions(false),m_types(this)
+	{
+		m_jit = new asmjit::JitRuntime();
+		m_instructions += encode(vm_instruction::term);
+
+		vm_type* tp = nullptr;
+		tp = m_types.add("integer", typeid(integer).name());
+		tp->is_primitive = true;
+		tp->size = sizeof(integer);
+
+		tp = m_types.add("decimal", typeid(decimal).name());
+		tp->is_primitive = true;
+		tp->size = sizeof(decimal);
+
+		tp = m_types.add("string", "char");
+		tp->is_primitive = false;
+		tp->size = sizeof(char*);
+
+		tp = m_types.add("void", "void");
+		tp->is_primitive = true;
+		tp->size = 0;
+	}
+
 	vm_context::~vm_context() {
+		delete m_jit;
 	}
 
 	void vm_context::add(const std::string& name, bind::wrapped_function* func) {
 	}
+
 	void vm_context::add(const std::string& name, bind::wrapped_class* cls) {
 	}
-	void vm_context::add(const std::string& name, script_function* func) {
+
+	void vm_context::add(const std::string& name, bind::script_function* func) {
 		m_script_functions[name] = func;
+	}
+
+	void vm_context::add(vm_function* func) {
+		u64 addr = 0;
+		if (func->is_host) addr = func->access.wrapped->address;
+		else addr = func->access.entry;
+
+		if (m_funcs_by_addr.count(addr) > 0) {
+			throw bind_exception(format("Function '%s' has already been added to the context", func->name.c_str()));
+		}
+
+		m_funcs_by_addr[addr] = func;
+		m_funcs[func->name] = func;
+	}
+
+	vm_function* vm_context::function(const std::string& name) {
+		auto it = m_funcs.find(name);
+		if (it == m_funcs.end()) return nullptr;
+		return it->getSecond();
+	}
+	vm_function* vm_context::function(u64 address) {
+		auto it = m_funcs_by_addr.find(address);
+		if (it == m_funcs_by_addr.end()) return nullptr;
+		return it->getSecond();
+	}
+	std::vector<vm_function*> vm_context::all_functions() {
+		std::vector<vm_function*> out;
+		for (auto i = m_funcs.begin();i != m_funcs.end();++i) {
+			out.push_back(i->getSecond());
+		}
+		return out;
 	}
 
 	bind::wrapped_function* vm_context::host_function(const std::string& name) {
 		return nullptr;
 	}
+
 	bind::wrapped_class* vm_context::host_prototype(const std::string& name) {
 		return nullptr;
 	}
-	script_function* vm_context::function(const std::string& name) {
+
+	bind::script_function* vm_context::_function(const std::string& name) {
 		return m_script_functions[name];
 	}
 
+	std::vector<bind::wrapped_class*> vm_context::host_prototypes() {
+		std::vector<bind::wrapped_class*> out;
+		for (auto i = m_host_classes.begin();i != m_host_classes.end();++i) {
+			out.push_back(i->getSecond());
+		}
+		return out;
+	}
+
+	std::vector<bind::wrapped_function*> vm_context::host_functions() {
+		std::vector<bind::wrapped_function*> out;
+		for (auto i = m_host_functions.begin();i != m_host_functions.end();++i) {
+			out.push_back(i->getSecond());
+		}
+		return out;
+	}
+
+	void vm_context::add_code(const std::string& filename, const std::string& code) {
+		try {
+			ast_node* ast = parse_source(this, filename, code);
+			compile_ast(this, ast, &m_instructions);
+		} catch (parse_exception& e) {
+			if (!m_catch_exceptions) throw e;
+			printf("%s:%d:%d: %s\n", e.file.c_str(), e.line, e.col, e.text.c_str());
+			std::string ln = "";
+			u32 wscount = 0;
+			bool reachedText = false;
+			for (u32 i = 0;i < e.lineText.length();i++) {
+				if (isspace(e.lineText[i]) && !reachedText) wscount++;
+				else {
+					reachedText = true;
+					ln += e.lineText[i];
+				}
+			}
+			printf("%s\n", ln.c_str());
+			for (u32 i = 0;i < e.col - wscount;i++) printf(" ");
+			printf("^\n");
+		} catch (compile_exception& e) {
+			if (!m_catch_exceptions) throw e;
+			printf("%s:%d:%d: %s\n", e.file.c_str(), e.line, e.col, e.text.c_str());
+			std::string ln = "";
+			u32 wscount = 0;
+			bool reachedText = false;
+			for (u32 i = 0;i < e.lineText.length();i++) {
+				if (isspace(e.lineText[i]) && !reachedText) wscount++;
+				else {
+					reachedText = true;
+					ln += e.lineText[i];
+				}
+			}
+			printf("%s\n", ln.c_str());
+			for (u32 i = 0;i < e.col - wscount;i++) printf(" ");
+			printf("^\n");
+		} catch (std::exception& e) {
+			if (!m_catch_exceptions) throw e;
+			printf("Caught exception: %s\n", e.what());
+		}
+	}
+
 	void vm_context::execute(address entry) {
-		m_vm.execute(m_instructions, entry);
-	}
+		m_is_executing = true;
 
-	void set_arguments(script_function* func, u8 idx) {
-	}
+		try {
+			m_vm.execute(m_instructions, entry);
+		} catch (runtime_exception& e) {
+			if (!m_catch_exceptions) throw e;
+			if (e.raised_from_script) {
+				printf("%s:%d:%d: %s\n", e.file.c_str(), e.line, e.col, e.text.c_str());
+				std::string ln = "";
+				u32 wscount = 0;
+				bool reachedText = false;
+				for (u32 i = 0;i < e.lineText.length();i++) {
+					if (isspace(e.lineText[i]) && !reachedText) wscount++;
+					else {
+						reachedText = true;
+						ln += e.lineText[i];
+					}
+				}
+				printf("%s\n", ln.c_str());
+				for (u32 i = 0;i < e.col - wscount;i++) printf(" ");
+				printf("^\n");
+			} else printf("%s\n", e.text.c_str());
+		} catch (std::exception& e) {
+			if (!m_catch_exceptions) throw e;
+			printf("Caught exception: %s\n", e.what());
+		}
 
-	template<>
-	void from_reg<integer>(integer* out, u64* reg_ptr) {
-		*out = *(integer*)reg_ptr;
-	}
-
-	template<>
-	void to_reg<integer>(const integer& in, u64* reg_ptr) {
-		(*(integer*)reg_ptr) = in;
+		m_is_executing = false;
 	}
 };

--- a/src/context.h
+++ b/src/context.h
@@ -82,14 +82,24 @@ namespace gjs {
 	};
 
 	namespace bind {
+		template <class T>
+		void to_reg(vm_context* context, T* const& in, u64* reg_ptr) {
+			*reg_ptr = reinterpret_cast<u64>(in);
+		}
+
+		template <class T>
+		void from_reg(vm_context* context, T** out, u64* reg_ptr) {
+			*out = reinterpret_cast<T*>(*reg_ptr);
+		}
+
 		template <typename T>
 		void to_reg(vm_context* context, const T& in, u64* reg_ptr) {
-			throw runtime_exception(context, format("No binding exists for storing type '%s' in a register", typeid(T).name));
+			throw runtime_exception(context, format("No binding exists for storing type '%s' in a register", typeid(T).name()));
 		}
 
 		template <typename T>
 		void from_reg(vm_context* context, T* out, u64* reg_ptr) {
-			throw runtime_exception(context, format("No binding exists for retrieving type '%s' from a register", typeid(T).name));
+			throw runtime_exception(context, format("No binding exists for retrieving type '%s' from a register", typeid(T).name()));
 		}
 
 		template <typename T, typename... Args>

--- a/src/context.h
+++ b/src/context.h
@@ -1,40 +1,34 @@
 #pragma once
 #include <robin_hood.h>
 #include <string>
-#include <any>
 #include <vm.h>
+#include <bind.h>
+#include <source_map.h>
+#include <util.h>
+
+namespace asmjit {
+	class JitRuntime;
+};
 
 namespace gjs {
-	namespace bind {
-		struct wrapped_function;
-		struct wrapped_class;
-	};
-
-	enum class value_type {
-		integer,
-		decimal,
-		string,
-		object
-	};
-
-	struct vec3 { float x,y,z; };
-
 	class vm_context;
-	struct script_function {
-		vm_context* ctx;
-		address entry;
-		value_type ret_type;
-		vm_register ret_location;
-		std::vector<value_type> arg_types;
-		std::vector<vm_register> arg_locs;
+	class runtime_exception : public std::exception {
+		public:
+			runtime_exception(vm_context* ctx, const std::string& text);
+			runtime_exception(const std::string& text);
+			~runtime_exception();
 
-		template <typename T, typename... Args>
-		void call(T* result, Args... args);
+			virtual char const* what() const { return text.c_str(); }
+
+			bool raised_from_script;
+			std::string file;
+			std::string lineText;
+			std::string text;
+			u32 line;
+			u32 col;
 	};
 
-	struct script_class {
-	};
-
+	class type_manager;
 	class vm_context {
 		public:
 			vm_context(vm_allocator* alloc, u32 stack_size, u32 mem_size);
@@ -42,106 +36,125 @@ namespace gjs {
 
 			void add(const std::string& name, bind::wrapped_function* func);
 			void add(const std::string& name, bind::wrapped_class* cls);
-			void add(const std::string& name, script_function* func);
+			void add(const std::string& name, bind::script_function* func);
 
 			bind::wrapped_function* host_function(const std::string& name);
 			bind::wrapped_class* host_prototype(const std::string& name);
-			script_function* function(const std::string& name);
+			bind::script_function* _function(const std::string& name);
+			std::vector<bind::wrapped_class*> host_prototypes();
+			std::vector<bind::wrapped_function*> host_functions();
+
+			void add(vm_function* func);
+			vm_function* function(const std::string& name);
+			vm_function* function(u64 address);
+			std::vector<vm_function*> all_functions();
+
 
 			inline vm_state* state() { return &m_vm.state; }
 			inline instruction_array* code() { return &m_instructions; }
+			inline source_map* map() { return &m_map; }
+			inline type_manager* types() { return &m_types; }
+			inline asmjit::JitRuntime* jit() { return m_jit; }
+			inline bool is_executing() const { return m_is_executing; }
+			inline bool log_exceptions() const { return m_catch_exceptions; }
+			inline void log_exceptions(bool doLog) { m_catch_exceptions = doLog; }
 
+			void add_code(const std::string& filename, const std::string& code);
 			void execute(address entry);
 
 
 		protected:
-			robin_hood::unordered_map<std::string, bind::wrapped_function*> m_host_functions;
-			robin_hood::unordered_map<std::string, script_function*> m_script_functions;
-			robin_hood::unordered_map<std::string, bind::wrapped_class*> m_host_classes;
+			robin_hood::unordered_map<u64, vm_function*> m_funcs_by_addr;
+			robin_hood::unordered_map<std::string, vm_function*> m_funcs;
+
+			asmjit::JitRuntime* m_jit;
+			type_manager m_types;
 			vm m_vm;
 			instruction_array m_instructions;
+			source_map m_map;
+			bool m_is_executing;
+			bool m_catch_exceptions;
+
+			// about to be removed
+			robin_hood::unordered_map<std::string, bind::wrapped_function*> m_host_functions;
+			robin_hood::unordered_map<std::string, bind::script_function*> m_script_functions;
+			robin_hood::unordered_map<std::string, bind::wrapped_class*> m_host_classes;
 	};
 
-	template <typename T>
-	void to_reg(const T& in, u64* reg_ptr) {
-	}
-
-	template <>
-	void to_reg<integer>(const integer& in, u64* reg_ptr);
-
-	template <typename Arg, typename... Args>
-	void set_arguments(script_function* func, u8 idx, const Arg& a, Args... rest) {
-		vm_state* state = func->ctx->state();
-
-		switch (func->arg_types[idx]) {
-			case value_type::integer: {
-				break;
-			}
-			case value_type::decimal: {
-				break;
-			}
-			case value_type::string: {
-				break;
-			}
-			case value_type::object: {
-				break;
-			}
+	namespace bind {
+		template <typename T>
+		void to_reg(vm_context* context, const T& in, u64* reg_ptr) {
+			throw runtime_exception(context, format("No binding exists for storing type '%s' in a register", typeid(T).name));
 		}
 
-		to_reg<Arg>(a, &state->registers[(integer)func->arg_locs[idx]]);
-
-		if (sizeof...(rest) == 0) return;
-		set_arguments(func, idx + 1, rest...);
-	}
-	void set_arguments(script_function* func, u8 idx);
-
-
-
-	template <typename T>
-	void from_reg(T* out, u64* reg_ptr) {
-	}
-
-	template <>
-	void from_reg<integer>(integer* out, u64* reg_ptr);
-
-	template <typename T, typename... Args>
-	void script_function::call(T* result, Args... args) {
-		if (sizeof...(args) != arg_locs.size()) {
-			// exception
+		template <typename T>
+		void from_reg(vm_context* context, T* out, u64* reg_ptr) {
+			throw runtime_exception(context, format("No binding exists for retrieving type '%s' from a register", typeid(T).name));
 		}
 
-		if (arg_locs.size() > 0) set_arguments(this, 0, args...);
-		ctx->execute(entry);
+		template <typename T, typename... Args>
+		void script_function::call(T* result, Args... args) {
+			try {
+				if (sizeof...(args) != arg_locs.size()) {
+					throw runtime_exception(format("Script function '%s' takes %d arguments, %d %s provided", name.c_str(), arg_locs.size(), sizeof...(args), (sizeof...(args)) == 1 ? "was" : "were"));
+				}
 
-		vm_state* state = ctx->state();
+				if (arg_locs.size() > 0) set_arguments(this, 0, args...);
+				ctx->execute(entry);
 
-		switch (ret_type) {
-			case value_type::integer: {
-				if (!std::is_integral_v<T>) {
-					// exception
+				vm_state* state = ctx->state();
+
+				switch (ret_type) {
+					case value_type::integer: {
+						if (!std::is_integral_v<T>) {
+							throw runtime_exception(format("Return value of script function '%s' is type 'integer', but non-integral type '%s' was provided", name.c_str(), typeid(T).name()));
+						}
+						break;
+					}
+					case value_type::decimal: {
+						if (!std::is_floating_point_v<T>) {
+							throw runtime_exception(format("Return value of script function '%s' is type 'decimal', but non-floating point type '%s' was provided", name.c_str(), typeid(T).name()));
+						}
+						break;
+					}
+					case value_type::string: {
+						if (!std::is_same_v<T, char*> && !std::is_same_v<T, std::string>) {
+							throw runtime_exception(format("Return value of script function '%s' is type 'string', but non-string type '%s' was provided", name.c_str(), typeid(T).name()));
+						}
+						break;
+					}
+					case value_type::object: {
+						if (!std::is_pointer_v<T>) {
+							// exception
+							throw runtime_exception(format("Return value of script function '%s' is type 'object', but non-pointer type '%s' was provided", name.c_str(), typeid(T).name()));
+						}
+						break;
+					}
 				}
-				break;
-			}
-			case value_type::decimal: {
-				if (!std::is_floating_point_v<T>) {
-					// exception
-				}
-				break;
-			}
-			case value_type::string: {
-				if (!std::is_same_v<T, char*>) {
-					// exception
-				}
-				break;
-			}
-			case value_type::object: {
-				if (!std::is_reference_v<T> && !std::is_pointer_v<T>) {
-					// exception
-				}
-				break;
+
+				from_reg(ctx, result, &state->registers[(integer)ret_location]);
+			}  catch (runtime_exception& e) {
+				if (!ctx->log_exceptions()) throw e;
+				if (e.raised_from_script) {
+					printf("%s:%d:%d: %s\n", e.file.c_str(), e.line, e.col, e.text.c_str());
+					std::string ln = "";
+					u32 wscount = 0;
+					bool reachedText = false;
+					for (u32 i = 0;i < e.lineText.length();i++) {
+						if (isspace(e.lineText[i]) && !reachedText) wscount++;
+						else {
+							reachedText = true;
+							ln += e.lineText[i];
+						}
+					}
+					printf("%s\n", ln.c_str());
+					for (u32 i = 0;i < e.col - wscount;i++) printf(" ");
+					printf("^\n");
+				} else printf("%s\n", e.text.c_str());
+			} catch (std::exception& e) {
+				if (!ctx->log_exceptions()) throw e;
+				printf("Caught exception: %s\n", e.what());
 			}
 		}
-
-		from_reg(result, &state->registers[(integer)ret_location]);
-	}
+	};
 };

--- a/src/context.h
+++ b/src/context.h
@@ -1,10 +1,12 @@
 #pragma once
-#include <robin_hood.h>
-#include <string>
 #include <vm.h>
 #include <bind.h>
 #include <source_map.h>
 #include <util.h>
+#include <pipeline.h>
+
+#include <robin_hood.h>
+#include <string>
 
 namespace asmjit {
 	class JitRuntime;
@@ -49,16 +51,19 @@ namespace gjs {
 			void add(vm_function* func);
 			vm_function* function(const std::string& name);
 			vm_function* function(u64 address);
+			bool set_function_address(u64 old_addr, u64 new_addr);
 
 			std::vector<vm_function*> all_functions();
 			std::vector<vm_type*> all_types();
 
-			inline vm_state*			state	() { return &m_vm.state; }
-			inline instruction_array*	code	() { return &m_instructions; }
-			inline source_map*			map		() { return &m_map; }
-			inline type_manager*		types	() { return &m_types; }
-			inline gjs::vm*				vm		() { return &m_vm; }
-			inline asmjit::JitRuntime*	jit		() { return m_jit; }
+			inline vm_state*			state		() { return &m_vm.state; }
+			inline instruction_array*	code		() { return &m_instructions; }
+			inline source_map*			map			() { return &m_map; }
+			inline type_manager*		types		() { return &m_types; }
+			inline gjs::vm*				vm			() { return &m_vm; }
+			inline asmjit::JitRuntime*	jit			() { return m_jit; }
+			inline vm_allocator*		allocator	() { return m_alloc; }
+			inline pipeline*			compiler	() { return &m_pipeline; }
 
 			inline bool is_executing	() const { return m_is_executing; }
 			inline bool log_exceptions	() const { return m_catch_exceptions; }
@@ -69,7 +74,6 @@ namespace gjs {
 			void add_code(const std::string& filename, const std::string& code);
 			void execute(address entry);
 
-
 		protected:
 			robin_hood::unordered_map<u64, vm_function*> m_funcs_by_addr;
 			robin_hood::unordered_map<std::string, vm_function*> m_funcs;
@@ -79,6 +83,8 @@ namespace gjs {
 			gjs::vm m_vm;
 			instruction_array m_instructions;
 			source_map m_map;
+			vm_allocator* m_alloc;
+			pipeline m_pipeline;
 			bool m_is_executing;
 			bool m_catch_exceptions;
 			bool m_log_instructions;

--- a/src/context.h
+++ b/src/context.h
@@ -34,30 +34,37 @@ namespace gjs {
 			vm_context(vm_allocator* alloc, u32 stack_size, u32 mem_size);
 			~vm_context();
 
-			void add(const std::string& name, bind::wrapped_function* func);
-			void add(const std::string& name, bind::wrapped_class* cls);
-			void add(const std::string& name, bind::script_function* func);
+			template <class Cls>
+			bind::wrap_class<Cls>& bind(const std::string& name) {
+				// as long as wrap_class::finalize is called, this will be deleted when it should be
+				return *(new bind::wrap_class<Cls>(&m_types, *m_jit, name));
+			}
 
-			bind::wrapped_function* host_function(const std::string& name);
-			bind::wrapped_class* host_prototype(const std::string& name);
-			bind::script_function* _function(const std::string& name);
-			std::vector<bind::wrapped_class*> host_prototypes();
-			std::vector<bind::wrapped_function*> host_functions();
+			template <typename Ret, typename... Args>
+			void bind(Ret(*func)(Args...), const std::string& name) {
+				bind::wrapped_function* w = bind::wrap(&m_types, *m_jit, name, func);
+				new vm_function(&m_types, w);
+			}
 
 			void add(vm_function* func);
 			vm_function* function(const std::string& name);
 			vm_function* function(u64 address);
+
 			std::vector<vm_function*> all_functions();
+			std::vector<vm_type*> all_types();
 
+			inline vm_state*			state	() { return &m_vm.state; }
+			inline instruction_array*	code	() { return &m_instructions; }
+			inline source_map*			map		() { return &m_map; }
+			inline type_manager*		types	() { return &m_types; }
+			inline gjs::vm*				vm		() { return &m_vm; }
+			inline asmjit::JitRuntime*	jit		() { return m_jit; }
 
-			inline vm_state* state() { return &m_vm.state; }
-			inline instruction_array* code() { return &m_instructions; }
-			inline source_map* map() { return &m_map; }
-			inline type_manager* types() { return &m_types; }
-			inline asmjit::JitRuntime* jit() { return m_jit; }
-			inline bool is_executing() const { return m_is_executing; }
-			inline bool log_exceptions() const { return m_catch_exceptions; }
-			inline void log_exceptions(bool doLog) { m_catch_exceptions = doLog; }
+			inline bool is_executing	() const { return m_is_executing; }
+			inline bool log_exceptions	() const { return m_catch_exceptions; }
+			inline bool log_instructions() const { return m_log_instructions; }
+			inline void log_exceptions	(bool doLog) { m_catch_exceptions = doLog; }
+			inline void log_instructions(bool doLog) { m_log_instructions = doLog; }
 
 			void add_code(const std::string& filename, const std::string& code);
 			void execute(address entry);
@@ -69,16 +76,12 @@ namespace gjs {
 
 			asmjit::JitRuntime* m_jit;
 			type_manager m_types;
-			vm m_vm;
+			gjs::vm m_vm;
 			instruction_array m_instructions;
 			source_map m_map;
 			bool m_is_executing;
 			bool m_catch_exceptions;
-
-			// about to be removed
-			robin_hood::unordered_map<std::string, bind::wrapped_function*> m_host_functions;
-			robin_hood::unordered_map<std::string, bind::script_function*> m_script_functions;
-			robin_hood::unordered_map<std::string, bind::wrapped_class*> m_host_classes;
+			bool m_log_instructions;
 	};
 
 	namespace bind {
@@ -100,71 +103,6 @@ namespace gjs {
 		template <typename T>
 		void from_reg(vm_context* context, T* out, u64* reg_ptr) {
 			throw runtime_exception(context, format("No binding exists for retrieving type '%s' from a register", typeid(T).name()));
-		}
-
-		template <typename T, typename... Args>
-		void script_function::call(T* result, Args... args) {
-			try {
-				if (sizeof...(args) != arg_locs.size()) {
-					throw runtime_exception(format("Script function '%s' takes %d arguments, %d %s provided", name.c_str(), arg_locs.size(), sizeof...(args), (sizeof...(args)) == 1 ? "was" : "were"));
-				}
-
-				if (arg_locs.size() > 0) set_arguments(this, 0, args...);
-				ctx->execute(entry);
-
-				vm_state* state = ctx->state();
-
-				switch (ret_type) {
-					case value_type::integer: {
-						if (!std::is_integral_v<T>) {
-							throw runtime_exception(format("Return value of script function '%s' is type 'integer', but non-integral type '%s' was provided", name.c_str(), typeid(T).name()));
-						}
-						break;
-					}
-					case value_type::decimal: {
-						if (!std::is_floating_point_v<T>) {
-							throw runtime_exception(format("Return value of script function '%s' is type 'decimal', but non-floating point type '%s' was provided", name.c_str(), typeid(T).name()));
-						}
-						break;
-					}
-					case value_type::string: {
-						if (!std::is_same_v<T, char*> && !std::is_same_v<T, std::string>) {
-							throw runtime_exception(format("Return value of script function '%s' is type 'string', but non-string type '%s' was provided", name.c_str(), typeid(T).name()));
-						}
-						break;
-					}
-					case value_type::object: {
-						if (!std::is_pointer_v<T>) {
-							// exception
-							throw runtime_exception(format("Return value of script function '%s' is type 'object', but non-pointer type '%s' was provided", name.c_str(), typeid(T).name()));
-						}
-						break;
-					}
-				}
-
-				from_reg(ctx, result, &state->registers[(integer)ret_location]);
-			}  catch (runtime_exception& e) {
-				if (!ctx->log_exceptions()) throw e;
-				if (e.raised_from_script) {
-					printf("%s:%d:%d: %s\n", e.file.c_str(), e.line, e.col, e.text.c_str());
-					std::string ln = "";
-					u32 wscount = 0;
-					bool reachedText = false;
-					for (u32 i = 0;i < e.lineText.length();i++) {
-						if (isspace(e.lineText[i]) && !reachedText) wscount++;
-						else {
-							reachedText = true;
-							ln += e.lineText[i];
-						}
-					}
-					printf("%s\n", ln.c_str());
-					for (u32 i = 0;i < e.col - wscount;i++) printf(" ");
-					printf("^\n");
-				} else printf("%s\n", e.text.c_str());
-			} catch (std::exception& e) {
-				if (!ctx->log_exceptions()) throw e;
-				printf("Caught exception: %s\n", e.what());
-			}
 		}
 	};
 };

--- a/src/default_steps.cpp
+++ b/src/default_steps.cpp
@@ -1,0 +1,96 @@
+#include <default_steps.h>
+#include <instruction_array.h>
+#include <source_map.h>
+#include <context.h>
+
+using namespace std;
+
+namespace gjs {
+	using vmi = vm_instruction;
+	using vmr = vm_register;
+
+	void remove_instruction(vm_context* ctx, instruction_array& ir, source_map* map, u32 addr, u32 start_addr) {
+		ir.remove(addr);
+		map->map.erase(map->map.begin() + addr);
+
+		for (u32 a = start_addr;a < ir.size();a++) {
+			vmi i = decode_instruction(ir[a]);
+
+			switch (i) {
+				case vmi::beqz:
+				case vmi::bneqz:
+				case vmi::bgtz:
+				case vmi::bgtez:
+				case vmi::bltz:
+				case vmi::bltez: {
+					vmr reg = decode_operand_1(ir[a]);
+					uinteger fail_addr = decode_operand_2ui(ir[a]);
+					if (fail_addr > addr) fail_addr--;
+					ir.set(a, encode(i).operand(reg).operand(fail_addr));
+					break;
+				}
+				case vmi::jmp:
+				case vmi::jal: {
+					u64 jmp_addr = decode_operand_1ui64(ir[a]);
+					if (jmp_addr > addr && jmp_addr <= ir.size()) jmp_addr--;
+					ir.set(a, encode(i).operand(jmp_addr));
+					break;
+				}
+				default: {
+				}
+			}
+		}
+
+		vector<vm_function*> funcs = ctx->all_functions();
+		for (u16 i = 0;i < funcs.size();i++) {
+			if (funcs[i]->is_host) continue;
+			if (funcs[i]->access.entry > addr) ctx->set_function_address(funcs[i]->access.entry, funcs[i]->access.entry - 1);
+		}
+	}
+
+	void ir_remove_trailing_stack_loads(vm_context* ctx, instruction_array& ir, source_map* map, u32 start_addr) {
+		vmi min_load = vmi::ld8;
+		vmi max_load = vmi::ld64;
+		vector<u32> remove_addrs;
+		vm_function* cur_func = nullptr;
+		auto reg_is_safe = [](vmr reg, const vector<vmr>& safe) {
+			for (u8 s = 0;s < safe.size();s++) {
+				if (safe[s] == reg) return true;
+			}
+			return false;
+		};
+		for (u32 a = start_addr;a < ir.size();a++) {
+			vm_function* f = ctx->function(a);
+			if (f) cur_func = f;
+			if (!cur_func) continue;
+
+			vmi i = decode_instruction(ir[a]);
+			if (i >= min_load && i <= max_load && !reg_is_safe(decode_operand_1(ir[a]), { vmr::ra, cur_func->signature.return_loc })) {
+				remove_addrs.clear();
+				remove_addrs.push_back(a);
+				bool function_exits_after = true;
+				for (u32 b = a + 1;b < ir.size();b++) {
+					vmi ib = decode_instruction(ir[b]);
+					if (ib >= min_load && ib <= max_load) {
+						if (!reg_is_safe(decode_operand_1(ir[a]), { vmr::ra, cur_func->signature.return_loc })) {
+							remove_addrs.push_back(b);
+						}
+					} else if (ib == vmi::jmpr) {
+						vmr to = decode_operand_1(ir[b]);
+						if (to != vmr::ra) function_exits_after = false;
+						break;
+					} else {
+						function_exits_after = false;
+						break;
+					}
+				}
+
+				if (function_exits_after) {
+					for (auto it = remove_addrs.rbegin();it != remove_addrs.rend();it++) {
+						remove_instruction(ctx, ir, map, *it, start_addr);
+					}
+				}
+			}
+		}
+	}
+};

--- a/src/default_steps.h
+++ b/src/default_steps.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <types.h>
+
+namespace gjs {
+	class vm_context;
+	class instruction_array;
+	class source_map;
+
+	// Removes instructions for restoring registers (other than $ra and return register)
+	// from the stack after a function call when the function returns immediately after
+	void ir_remove_trailing_stack_loads(vm_context* ctx, instruction_array& ir, source_map* map, u32 start_addr);
+};

--- a/src/exception.h
+++ b/src/exception.h
@@ -1,0 +1,4 @@
+#pragma once
+namespace gjs {
+	
+};

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -102,8 +102,10 @@ namespace gjs {
 		"xori",
 		"sl",
 		"sli",
+		"slir",
 		"sr",
 		"sri",
+		"srir",
 
 		// control flow
 		"beqz",

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -31,6 +31,18 @@ namespace gjs {
 		"divi",
 		"divir",
 
+		// unsigned arithmetic
+		"addu",
+		"addui",
+		"subu",
+		"subui",
+		"subuir",
+		"mulu",
+		"mului",
+		"divu",
+		"divui",
+		"divuir",
+
 		// integer / floating point conversion
 		"ctf",
 		"cti",

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -69,7 +69,7 @@ namespace gjs {
 		fdivi			,	// divide register by immediate value				fdivi	(dest)	(a)		1.0		dest = a / 1.0
 		fdivir			,	// divide immediate value by register				fdivir	(dest)	(a)		1.0		dest = 1.0 / a
 
-		// comparison
+		// comparison (need unsigned counterparts still)
 		lt				,	// check if register less than register				lt		(dest)	(a)		(b)		dest = a < b
 		lti				,	// check if register less than immediate			lti		(dest)	(a)		1		dest = a < 1
 		lte				,	// check if register less than or equal register	lte		(dest)	(a)		(b)		dest = a <= b
@@ -112,8 +112,10 @@ namespace gjs {
 		xori			,	// exlusive or register and immediate value			xori	(dest)	(a)		0x0F	dest = a ^ 0x0F
 		sl				,	// shift bits left by amount from register			sl		(dest)	(a)		(b)		dest = a << b
 		sli				,	// shift bits left by immediate value				sli		(dest)	(a)		4		dest = a << 4
+		slir			,	// shift bits of immediate left by register value	slir	(dest)	(a)		4		dest = 4 << a
 		sr				,	// shift bits right by amount from register			sr		(dest)	(a)		(b)		dest = a >> b
 		sri				,	// shift bits right by immediate value				sri		(dest)	(a)		4		dest = a >> 4
+		srir			,	// shift bits of immediate right by register value	sri		(dest)	(a)		4		dest = 4 >> a
 
 		// control flow
 		beqz			,	// branch if register equals zero					beqz	(a)		(fail_addr)		if a: goto fail_addr

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -41,6 +41,18 @@ namespace gjs {
 		divi			,	// divide register by immediate value				divi	(dest)	(a)		1.0		dest = a / 1
 		divir			,	// divide immediate value by register				divir	(dest)	(a)		1.0		dest = 1 / a
 
+		// unsigned integer arithmetic
+		addu			,	// add two registers								addu	(dest)	(a)		(b)		dest = a + b
+		addui			,	// add register and immediate value					addui	(dest)	(a)		1.0		dest = a + 1
+		subu			,	// subtract register from another					subu	(dest)	(a)		(b)		dest = a - b
+		subui			,	// subtract immediate value from register			subui	(dest)	(a)		1.0		dest = a - 1
+		subuir			,	// subtract register from immediate value			subuir	(dest)	(a)		1.0		dest = 1 - a
+		mulu			,	// multiply two registers							mulu	(dest)	(a)		(b)		dest = a * b
+		mului			,	// multiply register and immediate value			mului	(dest)	(a)		1.0		dest = a * 1
+		divu			,	// divide register by another						divu	(dest)	(a)		(b)		dest = a / b
+		divui			,	// divide register by immediate value				divui	(dest)	(a)		1.0		dest = a / 1
+		divuir			,	// divide immediate value by register				divuir	(dest)	(a)		1.0		dest = 1 / a
+
 		// integer / floating point conversion
 		ctf				,	// convert value to float							ctf		(a)						a = float(a)		(a must be fp)
 		cti				,	// convert float to integer							cti 	(a)						a = integer(a)		(a must be fp)

--- a/src/instruction_array.cpp
+++ b/src/instruction_array.cpp
@@ -34,4 +34,11 @@ namespace gjs {
 			memset(m_instructions + m_count, 0, RESIZE_AMOUNT * sizeof(instruction));
 		}
 	}
+
+	void instruction_array::remove(u32 index) {
+		for (u32 i = index;i < m_count - 1;i++) {
+			m_instructions[i] = m_instructions[i + 1];
+		}
+		if (m_count > 0) m_count--;
+	}
 };

--- a/src/instruction_array.h
+++ b/src/instruction_array.h
@@ -17,6 +17,7 @@ namespace gjs {
 			inline void set(u32 index, const instruction_encoder& i) { m_instructions[index] = i; }
 			inline void set(u32 index, instruction i) { m_instructions[index] = i; }
 			inline u32 size() const { return m_count; }
+			void remove(u32 index);
 
 		protected:
 			vm_allocator* m_allocator;

--- a/src/instruction_encoder.cpp
+++ b/src/instruction_encoder.cpp
@@ -101,7 +101,9 @@ namespace gjs {
 			|| x == vmi::bori		\
 			|| x == vmi::xori		\
 			|| x == vmi::sli		\
+			|| x == vmi::slir		\
 			|| x == vmi::sri		\
+			|| x == vmi::srir		\
 			|| x == vmi::andi		\
 			|| x == vmi::ori		\
 			|| x == vmi::lti		\
@@ -292,7 +294,7 @@ namespace gjs {
 				return *this;
 			}
 
-			if (third_operand_must_be_fpr(instr) != (is_fpr(reg) || reg == vmr::zero)) {
+			if ((third_operand_must_be_fpr(instr) && !(is_fpr(reg) || reg == vmr::zero)) || (!third_operand_must_be_fpr(instr) && is_fpr(reg))) {
 				// invalid operand
 				// exception
 				return *this;
@@ -313,7 +315,7 @@ namespace gjs {
 				return *this;
 			}
 
-			if (second_operand_must_be_fpr(instr) != (is_fpr(reg) || reg == vmr::zero)) {
+			if ((second_operand_must_be_fpr(instr) && !(is_fpr(reg) || reg == vmr::zero)) || (!second_operand_must_be_fpr(instr) && is_fpr(reg))) {
 				// invalid operand
 				// exception
 				return *this;
@@ -584,7 +586,7 @@ namespace gjs {
 		};
 
 		out += instruction_str[(u8)i];
-		out += ' ';
+		while (out.length() < 8) out += ' ';
 		if (check_instr_type_1(i)) {
 			u64 o1 = decode_operand_1ui64(code);
 			char addr[64] = { 0 };
@@ -603,7 +605,7 @@ namespace gjs {
 			out += reg_str(o1);
 			out += ", ";
 
-			integer o2 = decode_operand_2i(code);
+			integer o2 = decode_operand_2ui(code);
 			char addr[32] = { 0 };
 			_itoa_s<32>(o2, addr, 16);
 			out += "0x";

--- a/src/instruction_encoder.h
+++ b/src/instruction_encoder.h
@@ -30,6 +30,7 @@ namespace gjs {
 
 			instruction_encoder& operand(vm_register reg);
 			instruction_encoder& operand(integer immediate);
+			instruction_encoder& operand(uinteger immediate);
 			instruction_encoder& operand(decimal immediate);
 
 			inline operator instruction() const { return m_result; }
@@ -55,12 +56,15 @@ namespace gjs {
 	FORCE_INLINE vm_instruction decode_instruction			(instruction i) { return (vm_instruction)(i >> instruction_shift); }
 	FORCE_INLINE vm_register	decode_operand_1			(instruction i) { return (vm_register)(((i >> operand_1r_shift) | operand_register_mask) ^ operand_register_mask); }
 	FORCE_INLINE integer		decode_operand_1i			(instruction i) { return i >> operand_1i_shift; }
+	FORCE_INLINE uinteger		decode_operand_1ui			(instruction i) { return i >> operand_1i_shift; }
 	FORCE_INLINE vm_register	decode_operand_2			(instruction i) { return (vm_register)(((i >> operand_2r_shift) | operand_register_mask) ^ operand_register_mask); }
 	FORCE_INLINE integer		decode_operand_2i			(instruction i) { return i >> operand_2i_shift; }
+	FORCE_INLINE uinteger		decode_operand_2ui			(instruction i) { return i >> operand_2i_shift; }
 	FORCE_INLINE vm_register	decode_operand_3			(instruction i) { return (vm_register)(((i >> operand_3r_shift) | operand_register_mask) ^ operand_register_mask); }
 	FORCE_INLINE bool			decode_operator_3_is_float	(instruction i) { return (i >> operand_3_is_flt_shift) & 1; }
 	FORCE_INLINE decimal		decode_operand_3f			(instruction i) { float r; *((integer*)&r) = i >> operand_3i_shift; return r; }
 	FORCE_INLINE integer		decode_operand_3i			(instruction i) { return i >> operand_3i_shift; }
+	FORCE_INLINE uinteger		decode_operand_3ui			(instruction i) { return i >> operand_3i_shift; }
 
 	class vm_state;
 	std::string instruction_to_string(instruction i, vm_state* state = nullptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,145 +1,17 @@
-#include <instruction_encoder.h>
-#include <instruction.h>
-#include <register.h>
-#include <instruction_array.h>
 #include <allocator.h>
-#include <vm.h>
-#include <bind.h>
-#include <parse.h>
 #include <context.h>
-#include <compile.h>
-
-#include <stdio.h>
-#include <chrono>
 
 using namespace gjs;
 
-void test_vm() {
-	vm_allocator* alloc = new basic_malloc_allocator();
-	instruction_array a(alloc);
-	using vmi = vm_instruction;
-	using vmr = vm_register;
-
-	integer iterations = 100000000;
-
-	// float x = *mem[0xBE]
-	// int i = *mem[0xEF]
-	// while(i > 0) {
-	//	 i--
-	//	 x += 10.0f
-	// }
-	// *mem[0xBE] = x
-	vm cpu(alloc, 4096, 4096);
-	*(decimal*)cpu.state.memory[0xBE] = 0.0f;
-	*(integer*)cpu.state.memory[0xEF] = iterations + 1;
-	a += encode(vmi::ld32 ).operand(vmr::s0).operand(vmr::zero).operand(0xBE);  // 0: float x = *mem[0xBE]
-	a += encode(vmi::mtfp ).operand(vmr::s0).operand(vmr::f0  );				// 1: ^
-	a += encode(vmi::ld32 ).operand(vmr::v2).operand(vmr::zero).operand(0xEF);  // 2: int i = *mem[0xEF]
-	a += encode(vmi::subi ).operand(vmr::v2).operand(vmr::v2  ).operand(1	);  // 3: i--
-	a += encode(vmi::bneqz).operand(vmr::v2).operand(0x7      );			    // 4: if (i == 0) goto #7
-	a += encode(vmi::faddi).operand(vmr::f0).operand(vmr::f0  ).operand(0.1f);  // 5: x += 0.1f
-	a += encode(vmi::jmp  ).operand(0x3	   );									// 6: if (i > 0) goto #3
-	a += encode(vmi::mffp ).operand(vmr::f0).operand(vmr::s0  );				// 7: *mem[0xBE] = x
-	a += encode(vmi::st32 ).operand(vmr::s0).operand(vmr::zero).operand(0xBE);  // 8: ^
-	a += encode(vmi::term );													// 9: exit
-
-	std::chrono::high_resolution_clock::time_point tp0 = std::chrono::high_resolution_clock::now();
-	cpu.execute(a, 0);
-	std::chrono::high_resolution_clock::time_point tp1 = std::chrono::high_resolution_clock::now();
-	float tm0 = float(std::chrono::duration_cast<std::chrono::milliseconds>(tp1 - tp0).count()) / 1000.0f;
-
-
-	tp0 = std::chrono::high_resolution_clock::now();
-	float v = 5.0f;
-	integer i = iterations;
-	while (i > 0) {
-		i--;
-		v += 10.0f;
-	}
-	tp1 = std::chrono::high_resolution_clock::now();
-	float tm1 = float(std::chrono::duration_cast<std::chrono::milliseconds>(tp1 - tp0).count()) / 1000.0f;
-
-	float result = *(float*)cpu.state.memory[0xBE];
-	printf("\n\n\n\n\n\n\nResult: %f, in %f seconds (%fx native)\n\n\n\n\n\n", result, tm0, tm0 / tm1);
-}
-
 class foo {
 	public:
-		foo(int x) : y(x) { }
+		foo(int x) { y = x; }
 		~foo() { }
-
-		int print() { return printf("%d\n", y); }
-		int set_y(int z) { return y = z; }
-		int get_y() { return y; }
 
 		int y;
 };
 
-void test_bind() {
-	asmjit::JitRuntime rt;
-	bind::wrapped_function* func = bind::wrap(rt, &foo::print);
-	foo bar(15);
-	int x = std::any_cast<int>(func->call({ &bar }));
-	delete func;
-
-	bind::wrapped_function* construct = bind::wrap_constructor<foo, int>(rt);
-	foo* ayy = std::any_cast<foo*>(construct->call({ 52 }));
-
-	bind::wrap_class<foo> f(rt);
-	f.constructor<int>();
-	f.method("print", &foo::print);
-	f.prop("y", &foo::y);
-	f.prop("y", &foo::get_y, &foo::set_y);
-}
-
-void test_parse() {
-	const char* src =
-		"format fmt = { a: integer, b: decimal, c: function };\n"
-		"void something(fmt arg0, integer arg1);\n"
-		"class test {\n"
-		"    constructor(string ayy) {\n"
-		"        this.x = ayy;\n"
-		"        this.y = 10;\n"
-		"    }\n"
-		"    destructor() { }\n"
-		"    void p(decimal x) {\n"
-		"        decimal g = x;\n"
-		"        for (integer a = 0;a < this.y;a++) {\n"
-		"            this.x = this.x + ' ' + this.x;\n"
-		"        }\n"
-		"    }\n"
-		"    \n"
-		"    string x;\n"
-		"    integer y;\n"
-		"};\n"
-		"void something(fmt arg0, integer arg1) {\n"
-		"    integer x = arg0.a + arg1;\n"
-		"}\n";
-
-	vm_allocator* alloc = new basic_malloc_allocator();
-	vm_context ctx(alloc, 4096, 4096);
-	try {
-		ast_node* code = parse_source(&ctx, "test.gjs", src);
-		code->debug_print(0);
-	} catch (parse_exception& e) {
-		printf("%s:%d:%d: %s\n", e.file.c_str(), e.line, e.col, e.text.c_str());
-		std::string ln = "";
-		u32 wscount = 0;
-		bool reachedText = false;
-		for (u32 i = 0;i < e.lineText.length();i++) {
-			if (isspace(e.lineText[i]) && !reachedText) wscount++;
-			else {
-				reachedText = true;
-				ln += e.lineText[i];
-			}
-		}
-		printf("%s\n", ln.c_str());
-		for (u32 i = 0;i < e.col - wscount;i++) printf(" ");
-		printf("^\n");
-	}
-}
-
-void test_compile() {
+int main(int arg_count, const char** args) {
 	const char* src =
 		"integer test(integer x);\n"
 		"integer something(integer arg0, integer arg1, integer arg2) {\n"
@@ -157,41 +29,26 @@ void test_compile() {
 		"integer main() {\n"
 		"    return test1(100);\n"
 		"}\n";
+
 	vm_allocator* alloc = new basic_malloc_allocator();
 	vm_context ctx(alloc, 4096, 4096);
+	ctx.log_exceptions(true);
+
 	try {
-		ast_node* code = parse_source(&ctx, "test.gjs", src);
-		instruction_array* bcode = ctx.code();
-
-		// instruction 0 must be term, when the entry function exits
-		// it jumps to 0
-		(*bcode) += encode(vm_instruction::term);
-
-		compile_ast(&ctx, code, bcode);
-
-		integer result = 0;
-		ctx.function("test")->call(&result, 5);
-		printf("result: %d\n", result);
-	} catch (parse_exception& e) {
-		printf("%s:%d:%d: %s\n", e.file.c_str(), e.line, e.col, e.text.c_str());
-		std::string ln = "";
-		u32 wscount = 0;
-		bool reachedText = false;
-		for (u32 i = 0;i < e.lineText.length();i++) {
-			if (isspace(e.lineText[i]) && !reachedText) wscount++;
-			else {
-				reachedText = true;
-				ln += e.lineText[i];
-			}
-		}
-		printf("%s\n", ln.c_str());
-		for (u32 i = 0;i < e.col - wscount;i++) printf(" ");
-		printf("^\n");
+		bind::wrap_class<foo> f = bind::wrap_class<foo>(ctx.types(), *ctx.jit(), "foo");
+		f.constructor<integer>();
+		f.prop("y", &foo::y, bind::property_flags::pf_none);
+		f.finalize();
+	} catch (bind_exception& e) {
+		printf("%s\n", e.text.c_str());
 	}
-}
 
-int main(int arg_count, const char** args) {
-	//test();
-	test_compile();
+	vm_type* tp = ctx.types()->get<foo>();
+	ctx.add_code("test.gjs", src);
+
+	//integer result = 0;
+	//ctx.function("something")->call(&result, 1, 2, 3.0f);
+
+	//printf("result: %d\n", result);
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,17 +5,17 @@ using namespace gjs;
 
 class foo {
 	public:
-		foo(int* _x) { x = _x; w = 3.0f; }
+		foo(i32* _x) { x = _x; w = 3.0f; }
 		~foo() { }
 
-		integer t(integer a) {
+		i32 t(i32 a) {
 			return printf("%d, %d\n", y, a);
 		}
 
-		int* x;
-		int y;
-		int z;
-		float w;
+		i32* x;
+		i32 y;
+		i32 z;
+		f32 w;
 };
 
 void print_foo(const foo& f) {
@@ -24,31 +24,35 @@ void print_foo(const foo& f) {
 
 int main(int arg_count, const char** args) {
 	const char* src =
-		"integer test(integer x);\n"
-		"integer something(integer arg0, integer arg1, integer arg2) {\n"
-		"    integer x = arg0 + arg1 * 4.0;\n"
-		"    integer y = x - arg2;\n"
+		"i32 test(i32 x);\n"
+		"i32 something(i32 arg0, i32 arg1, i32 arg2) {\n"
+		"    i32 x = arg0 + arg1 * 4.0;\n"
+		"    i32 y = x - arg2;\n"
 		"    x = y++;\n"
+		"    for (i32 i = 0;i < 10;i++) {\n"
+		"        x += 3;\n"
+		"    }\n"
 		"    return test(x);\n"
 		"}\n"
-		"integer test(integer x) {\n"
+		"i32 test(i32 x) {\n"
 		"    return x * 5;\n"
 		"}\n"
-		"integer test1(integer z) {\n"
+		"i32 test1(i32 z) {\n"
 		"    return something(z, z + 1, z + 2);\n"
 		"}\n"
-		"integer main(foo a) {\n"
+		"i32 main(foo a) {\n"
 		"    a.x = 52;\n"
 		"    a.y *= 5;\n"
 		"    a.z = 2;\n"
 		"    a.w = 61.69;\n"
 		"    print_foo(a);\n"
-		"    return a.t(test1(100));;\n"
+		"    return a.t(test1(100));\n"
 		"}\n";
 
 	vm_allocator* alloc = new basic_malloc_allocator();
 	vm_context ctx(alloc, 4096, 4096);
 	ctx.log_exceptions(true);
+	ctx.log_instructions(true);
 
 	try {
 		auto f = ctx.bind<foo>("foo");
@@ -68,10 +72,11 @@ int main(int arg_count, const char** args) {
 	vm_type* tp = ctx.types()->get<foo>();
 	ctx.add_code("test.gjs", src);
 
+	std::string last_line = "";
 	for (u32 i = 0;i < ctx.code()->size();i++) {
 		vm_function* f = ctx.function(i);
 		if (f) {
-			printf("[%s %s(", f->signature.return_type->name.c_str(), f->name.c_str());
+			printf("\n[%s %s(", f->signature.return_type->name.c_str(), f->name.c_str());
 			for(u8 a = 0;a < f->signature.arg_types.size();a++) {
 				if (a > 0) printf(", ");
 				printf("%s arg_%d -> $%s", f->signature.arg_types[a]->name.c_str(), a, register_str[u8(f->signature.arg_locs[a])]);
@@ -82,7 +87,14 @@ int main(int arg_count, const char** args) {
 			else printf(" -> $%s", register_str[u8(f->signature.return_loc)]);
 			printf("]\n");
 		}
-		printf("0x%2.2X: %s\n", i, instruction_to_string((*ctx.code())[i]).c_str());
+		printf("0x%2.2X: %-32s", i, instruction_to_string((*ctx.code())[i]).c_str());
+
+		auto src = ctx.map()->get(i);
+		if (src.lineText != last_line) {
+			printf("; %s", src.lineText.c_str());
+			last_line = src.lineText;
+		}
+		printf("\n");
 	}
 	printf("-------------result-------------\n");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,17 +5,22 @@ using namespace gjs;
 
 class foo {
 	public:
-		foo(int* _x) { x = _x; }
+		foo(int* _x) { x = _x; w = 3.0f; }
 		~foo() { }
 
-		void t() {
-			printf("%d\n", y);
+		integer t(integer a) {
+			return printf("%d, %d\n", y, a);
 		}
 
 		int* x;
 		int y;
 		int z;
+		float w;
 };
+
+void print_foo(const foo& f) {
+	printf("foo: %d, %d, %d, %f\n", *f.x, f.y, f.z, f.w);
+}
 
 int main(int arg_count, const char** args) {
 	const char* src =
@@ -36,8 +41,9 @@ int main(int arg_count, const char** args) {
 		"    a.x = 52;\n"
 		"    a.y *= 5;\n"
 		"    a.z = 2;\n"
-		"    a.t();\n"
-		"    return test1(100);\n"
+		"    a.w = 61.69;\n"
+		"    print_foo(a);\n"
+		"    return a.t(test1(100));;\n"
 		"}\n";
 
 	vm_allocator* alloc = new basic_malloc_allocator();
@@ -45,13 +51,16 @@ int main(int arg_count, const char** args) {
 	ctx.log_exceptions(true);
 
 	try {
-		bind::wrap_class<foo> f = bind::wrap_class<foo>(ctx.types(), *ctx.jit(), "foo");
+		auto f = ctx.bind<foo>("foo");
 		f.constructor<integer*>();
 		f.method("t", &foo::t);
 		f.prop("x", &foo::x, bind::property_flags::pf_object_pointer);
 		f.prop("y", &foo::y, bind::property_flags::pf_none);
 		f.prop("z", &foo::z, bind::property_flags::pf_none);
+		f.prop("w", &foo::w, bind::property_flags::pf_none);
 		f.finalize();
+
+		ctx.bind(print_foo, "print_foo");
 	} catch (bind_exception& e) {
 		printf("%s\n", e.text.c_str());
 	}
@@ -60,17 +69,28 @@ int main(int arg_count, const char** args) {
 	ctx.add_code("test.gjs", src);
 
 	for (u32 i = 0;i < ctx.code()->size();i++) {
+		vm_function* f = ctx.function(i);
+		if (f) {
+			printf("[%s %s(", f->signature.return_type->name.c_str(), f->name.c_str());
+			for(u8 a = 0;a < f->signature.arg_types.size();a++) {
+				if (a > 0) printf(", ");
+				printf("%s arg_%d -> $%s", f->signature.arg_types[a]->name.c_str(), a, register_str[u8(f->signature.arg_locs[a])]);
+			}
+			printf(")");
+
+			if (f->signature.return_type->size == 0) printf(" -> null");
+			else printf(" -> $%s", register_str[u8(f->signature.return_loc)]);
+			printf("]\n");
+		}
 		printf("0x%2.2X: %s\n", i, instruction_to_string((*ctx.code())[i]).c_str());
 	}
+	printf("-------------result-------------\n");
 
 	int x = 5;
 	foo test(&x);
+	test.y = 10;
+	test.z = 4;
 	integer result = 0;
-	ctx._function("main")->call(&result, &test);
-
-	//integer result = 0;
-	//ctx.function("something")->call(&result, 1, 2, 3.0f);
-
-	//printf("result: %d\n", result);
+	ctx.function("main")->call(&result, &test);
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,10 +5,16 @@ using namespace gjs;
 
 class foo {
 	public:
-		foo(int x) { y = x; }
+		foo(int* _x) { x = _x; }
 		~foo() { }
 
+		void t() {
+			printf("%d\n", y);
+		}
+
+		int* x;
 		int y;
+		int z;
 };
 
 int main(int arg_count, const char** args) {
@@ -26,7 +32,11 @@ int main(int arg_count, const char** args) {
 		"integer test1(integer z) {\n"
 		"    return something(z, z + 1, z + 2);\n"
 		"}\n"
-		"integer main() {\n"
+		"integer main(foo a) {\n"
+		"    a.x = 52;\n"
+		"    a.y *= 5;\n"
+		"    a.z = 2;\n"
+		"    a.t();\n"
 		"    return test1(100);\n"
 		"}\n";
 
@@ -36,8 +46,11 @@ int main(int arg_count, const char** args) {
 
 	try {
 		bind::wrap_class<foo> f = bind::wrap_class<foo>(ctx.types(), *ctx.jit(), "foo");
-		f.constructor<integer>();
+		f.constructor<integer*>();
+		f.method("t", &foo::t);
+		f.prop("x", &foo::x, bind::property_flags::pf_object_pointer);
 		f.prop("y", &foo::y, bind::property_flags::pf_none);
+		f.prop("z", &foo::z, bind::property_flags::pf_none);
 		f.finalize();
 	} catch (bind_exception& e) {
 		printf("%s\n", e.text.c_str());
@@ -45,6 +58,15 @@ int main(int arg_count, const char** args) {
 
 	vm_type* tp = ctx.types()->get<foo>();
 	ctx.add_code("test.gjs", src);
+
+	for (u32 i = 0;i < ctx.code()->size();i++) {
+		printf("0x%2.2X: %s\n", i, instruction_to_string((*ctx.code())[i]).c_str());
+	}
+
+	int x = 5;
+	foo test(&x);
+	integer result = 0;
+	ctx._function("main")->call(&result, &test);
 
 	//integer result = 0;
 	//ctx.function("something")->call(&result, 1, 2, 3.0f);

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -47,7 +47,6 @@ namespace gjs {
 
 	ast_node* parse_next(parse_context& ctx, tokenizer& t);
 	ast_node* identifier(tokenizer& t, token& tk);
-	void add_node(parse_context& ctx, ast_node* node);
 	void init_tokenizer(tokenizer& t);
 
 
@@ -155,7 +154,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -195,7 +193,6 @@ namespace gjs {
 					);
 				}
 
-				add_node(ctx, cond);
 				set_node_src(cond, cur);
 				ret = cond;
 			}
@@ -222,7 +219,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -249,7 +245,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -276,7 +271,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -303,7 +297,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -330,7 +323,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -358,7 +350,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -388,7 +379,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -416,7 +406,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -444,7 +433,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -473,7 +461,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -500,7 +487,6 @@ namespace gjs {
 					);
 				}
 
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				return op;
 			}
@@ -525,7 +511,6 @@ namespace gjs {
 				if (cur.text == "--") op->op = ast_node::operation_type::postDec;
 				else op->op = ast_node::operation_type::postInc;
 				op->lvalue = ret;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				return op;
 			}
@@ -579,7 +564,6 @@ namespace gjs {
 				consume();
 
 				ret = c;
-				add_node(ctx, c);
 				set_node_src(c, cur);
 				cur = current();
 			}
@@ -609,7 +593,6 @@ namespace gjs {
 					if (t.is_identifier(current().text)) {
 						op->rvalue = identifier(t, current());
 						set_node_src(op->rvalue, current());
-						add_node(ctx, op->rvalue);
 						consume();
 					} else {
 						throw parse_exception(
@@ -630,7 +613,6 @@ namespace gjs {
 				}
 
 				ret = op;
-				add_node(ctx, op);
 				set_node_src(op, cur);
 				cur = current();
 			}
@@ -692,7 +674,6 @@ namespace gjs {
 				n->type = ast_node::node_type::identifier;
 				n->set(tok.text);
 				set_node_src(n, tok);
-				add_node(ctx, n);
 				return n;
 			}
 
@@ -707,7 +688,6 @@ namespace gjs {
 			node->c_type = ast_node::constant_type::integer;
 			node->value.i = tok.text == "true" ? 1 : 0;
 			set_node_src(node, tok);
-			add_node(ctx, node);
 			return node;
 		}
 
@@ -718,7 +698,6 @@ namespace gjs {
 				node->c_type = ast_node::constant_type::integer;
 				node->value.i = 0;
 				set_node_src(node, tok);
-				add_node(ctx, node);
 				return node;
 			}
 
@@ -733,7 +712,6 @@ namespace gjs {
 				node->value.i =	atoi(tok.text.c_str());
 			}
 			set_node_src(node, tok);
-			add_node(ctx, node);
 			return node;
 		}
 
@@ -744,7 +722,6 @@ namespace gjs {
 			node->c_type = ast_node::constant_type::string;
 			node->set(tok.text.substr(1, tok.text.length() - 2));
 			set_node_src(node, tok);
-			add_node(ctx, node);
 			return node;
 		}
 
@@ -774,7 +751,6 @@ namespace gjs {
 		next = nullptr;
 		data_type = nullptr;
 		identifier = nullptr;
-		literal = nullptr;
 		body = nullptr;
 		else_body = nullptr;
 		property = nullptr;
@@ -795,10 +771,22 @@ namespace gjs {
 	}
 
 	ast_node::~ast_node() {
-		if (value.s) delete [] value.s;
-		for (u32 i = 0;i < all_nodes.size();i++) {
-			delete all_nodes[i];
-		}
+		if (value.s && c_type == constant_type::string) delete [] value.s;
+		if (next) delete next;
+		if (data_type) delete data_type;
+		if (identifier) delete identifier;
+		if (body) delete body;
+		if (else_body) delete else_body;
+		if (property) delete property;
+		if (arguments) delete arguments;
+		if (initializer) delete initializer;
+		if (lvalue) delete lvalue;
+		if (rvalue) delete rvalue;
+		if (callee) delete callee;
+		if (constructor) delete constructor;
+		if (destructor) delete destructor;
+		if (condition) delete condition;
+		if (modifier) delete modifier;
 	}
 
 	void ast_node::debug_print(u32 tab_level, bool dontIndentFirst, bool inArray) {
@@ -928,7 +916,6 @@ namespace gjs {
 			data_type->debug_print(tab_level + indent, true);
 		}
 		if (identifier) child(identifier, "identifier");
-		if (literal) child(literal, "literal");
 		if (property) child(property, "property");
 		if (arguments) child(arguments, "arguments");
 		if (lvalue) child(lvalue, "lvalue");
@@ -965,33 +952,11 @@ namespace gjs {
 		return n;
 	}
 
-	void add_node(parse_context& ctx, ast_node* n) {
-		ctx.root->all_nodes.push_back(n);
-	}
-
 
 
 	ast_node* parse_data_type(parse_context& ctx, tokenizer& t) {
-		token type = t.keyword(false);
+		token type = t.identifier(false);
 		if (type) {
-			bool valid = false;
-			if (type == "integer") valid = true;
-			else if (type == "decimal") valid = true;
-			else if (type == "string") valid = true;
-			else if (type == "function") valid = true;
-			else if (type == "void") valid = true;
-
-			if (!valid) {
-				throw parse_exception(
-					format("Unexpected keyword '%s'", type.text.c_str()),
-					t, type
-				);
-				return nullptr;
-			}
-
-			return type_identifier(t, type);
-		}
-		else if ((bool)(type = t.identifier(false))) {
 			if (ctx.find_type(type.text)) return type_identifier(t, type);
 			else throw parse_exception("Expected type name", t, type);
 		} else {
@@ -1048,7 +1013,6 @@ namespace gjs {
 	ast_node* parse_variable_declaration(parse_context& ctx, tokenizer& t) {
 		ast_node* type = parse_data_type(ctx, t);
 		if (string(*type) == "void") {
-			add_node(ctx, type);
 			throw parse_exception(
 				t.file,
 				"Variables can not be declared void",
@@ -1064,11 +1028,9 @@ namespace gjs {
 
 		ast_node* vdecl = new ast_node();
 		vdecl->start = type->start;
-		add_node(ctx, vdecl);
 
 		vdecl->type = ast_node::node_type::variable_declaration;
 		vdecl->data_type = type;
-		add_node(ctx, vdecl->data_type);
 
 		token name = t.identifier();
 		ast_node* prevDecl = ctx.find_type(name.text);
@@ -1097,7 +1059,6 @@ namespace gjs {
 			init->src(t, eq);
 			init->body = parse_expression(ctx, t);
 			vdecl->initializer = init;
-			add_node(ctx, vdecl->initializer);
 		}
 
 		frame.variable_declarations.push_back(vdecl);
@@ -1110,26 +1071,13 @@ namespace gjs {
 		ast_node* arguments = new ast_node();
 		arguments->type = ast_node::node_type::function_arguments;
 		arguments->src(t, start);
-		add_node(ctx, arguments);
 
 		token end;
 		bool expectEnd = false;
 		while (!(bool)(end = t.character(')', expectEnd))) {
 			token type = t.keyword(false);
 			if (type) {
-				bool valid = false;
-				if (type == "integer") valid = true;
-				else if (type == "decimal") valid = true;
-				else if (type == "string") valid = true;
-				else if (type == "function") valid = true;
-				else if (type == "void") {
-					throw parse_exception(
-						"Variables can not be declared void",
-						t, type
-					);
-					return nullptr;
-				}
-				else if (type == "const") {
+				if (type == "const") {
 					throw parse_exception(
 						"Function arguments can't be declared const",
 						t, type
@@ -1144,13 +1092,11 @@ namespace gjs {
 					return nullptr;
 				}
 
-				if (!valid) {
-					throw parse_exception(
-						format("Unexpected keyword '%s'", type.text.c_str()),
-						t, type
-					);
-					return nullptr;
-				}
+				throw parse_exception(
+					format("Unexpected keyword '%s'", type.text.c_str()),
+					t, type
+				);
+				return nullptr;
 			}
 			else if ((bool)(type = t.identifier(false))) {
 				if (!ctx.find_type(type.text)) throw parse_exception("Expected type name", t, type);
@@ -1173,13 +1119,10 @@ namespace gjs {
 			ast_node* arg = new ast_node();
 			arg->type = ast_node::node_type::variable_declaration;
 			arg->src(t, type);
-			add_node(ctx, arg);
 
 			arg->data_type = type_identifier(t, type);
-			add_node(ctx, arg->data_type);
 
 			arg->identifier = identifier(t, name);
-			add_node(ctx, arg->identifier);
 
 			if (arguments->body) {
 				ast_node* n = arguments->body;
@@ -1213,7 +1156,6 @@ namespace gjs {
 
 			// make sure the return type is the same
 			if (string(*return_type) != string(*existing->data_type)) {
-				add_node(ctx, return_type);
 				throw parse_exception(
 					t.file,
 					format("Definition for function '%s' has different return type than its declaration", name.text.c_str()),
@@ -1251,7 +1193,6 @@ namespace gjs {
 			}
 
 			if (!same) {
-				add_node(ctx, return_type);
 				throw parse_exception(
 					t.file,
 					format("Definition for function '%s' has different arguments than its declaration", name.text.c_str()),
@@ -1268,10 +1209,8 @@ namespace gjs {
 
 			func = new ast_node();
 			func->type = ast_node::node_type::function_declaration;
-			add_node(ctx, func);
 
 			func->data_type = return_type;
-			add_node(ctx, func->data_type);
 			func->start = func->data_type->start;
 
 			ast_node* prevDecl = ctx.find_type(name.text);
@@ -1285,7 +1224,6 @@ namespace gjs {
 			}
 
 			func->identifier = identifier(t, name);
-			add_node(ctx, func->identifier);
 
 			ctx.frames[ctx.frames.size() - 1].variable_declarations.push_back(func);
 			ctx.node_path.push(func);
@@ -1293,7 +1231,9 @@ namespace gjs {
 			func->arguments = parse_function_declaration_arguments(ctx, t);
 		}
 
+		t.backup_state();
 		if (t.semicolon(false)) {
+			t.restore_state();
 			if (existing) {
 				throw parse_exception(
 					format("Function '%s' already has a forward declaration", name.text.c_str()),
@@ -1305,6 +1245,7 @@ namespace gjs {
 			ctx.node_path.pop();
 			return func;
 		}
+		t.restore_state();
 
 		if (existing) {
 			// function definition for forward declared function
@@ -1342,7 +1283,6 @@ namespace gjs {
 			ast_node* ret = new ast_node();
 			ret->type = ast_node::node_type::empty;
 			ret->start = func->data_type->start;
-			add_node(ctx, ret);
 			return ret;
 		}
 		return func;
@@ -1390,10 +1330,8 @@ namespace gjs {
 		ast_node* n = new ast_node();
 		n->type = ast_node::node_type::format_declaration;
 		n->src(t, start);
-		add_node(ctx, n);
 
 		n->identifier = parse_new_identifier(ctx, t);
-		add_node(ctx, n->identifier);
 
 		t.keyword(true, "=");
 
@@ -1419,7 +1357,6 @@ namespace gjs {
 
 			ast_node* type = parse_data_type(ctx, t);
 			if (string(*type) == "void") {
-				add_node(ctx, type);
 				throw parse_exception(
 					t.file,
 					"Format properties can not be declared void",
@@ -1433,13 +1370,8 @@ namespace gjs {
 			ast_node* prop = new ast_node();
 			prop->start = type->start;
 			prop->type = ast_node::node_type::format_property;
-			add_node(ctx, prop);
-
 			prop->data_type = type;
-			add_node(ctx, prop->data_type);
-
 			prop->identifier = identifier(t, name);
-			add_node(ctx, prop->identifier);
 
 			if (n->body) {
 				ast_node* p = n->body;
@@ -1475,9 +1407,7 @@ namespace gjs {
 		ast_node* c = new ast_node();
 		c->type = ast_node::node_type::class_declaration;
 		c->src(t, start);
-		add_node(ctx, c);
 		c->identifier = parse_new_identifier(ctx, t);
-		add_node(ctx, c->identifier);
 		ctx.frames[ctx.frames.size() - 1].type_declarations.push_back(c);
 		ctx.node_path.push(c);
 		ctx.frames.push_back(parse_frame());
@@ -1497,7 +1427,6 @@ namespace gjs {
 				ast_node* func = new ast_node();
 				func->type = ast_node::node_type::function_declaration;
 				func->src(t, tok);
-				ctx.root->all_nodes.push_back(func);
 
 				ctx.node_path.push(func);
 				ctx.frames.push_back(parse_frame());
@@ -1530,7 +1459,6 @@ namespace gjs {
 				ast_node* func = new ast_node();
 				func->type = ast_node::node_type::function_declaration;
 				func->src(t, tok);
-				ctx.root->all_nodes.push_back(func);
 
 				ctx.node_path.push(func);
 				ctx.frames.push_back(parse_frame());
@@ -1562,13 +1490,16 @@ namespace gjs {
 			t.restore_state();
 			ast_node* decl = nullptr;
 			if (first) {
-				if (first == "integer") decl = parse_declaration(ctx, t);
-				else if (first == "decimal") decl = parse_declaration(ctx, t);
-				else if (first == "string") decl = parse_declaration(ctx, t);
-				else if (first == "function") decl = parse_declaration(ctx, t);
-				else if (first == "void") decl = parse_declaration(ctx, t);
-				else if (first == "const") decl = parse_const_declaration(ctx, t);
+				if (first == "const") decl = parse_const_declaration(ctx, t);
 				else if (first == "static") decl = parse_static_declaration(ctx, t);
+			}
+			if (!decl) {
+				t.backup_state();
+				first = t.identifier(false);
+				t.restore_state();
+				if (first) {
+					if (ctx.find_type(first.text)) decl = parse_declaration(ctx, t);
+				}
 			}
 			
 			if (!decl) throw parse_exception("Expected class method or property declaration", t);
@@ -1604,11 +1535,9 @@ namespace gjs {
 		ast_node* stmt = new ast_node();
 		stmt->type = ast_node::node_type::if_statement;
 		stmt->src(t, start);
-		add_node(ctx, stmt);
 		ctx.node_path.push(stmt);
 
 		stmt->condition = parse_expression(ctx, t);
-		add_node(ctx, stmt->condition);
 
 		t.character(')');
 
@@ -1654,26 +1583,22 @@ namespace gjs {
 		ast_node* l = new ast_node();
 		l->type = ast_node::node_type::for_loop;
 		l->src(t, start);
-		add_node(ctx, l);
 		ctx.frames.push_back(parse_frame());
 		ctx.node_path.push(l);
 
 		t.character('(');
 		if (!t.character(';', false)) {
 			l->initializer = parse_variable_declaration(ctx, t);
-			add_node(ctx, l->initializer);
 			t.character(';');
 		}
 
 		if (!t.character(';', false)) {
 			l->condition = parse_expression(ctx, t);
-			add_node(ctx, l->condition);
 			t.character(';');
 		}
 
 		if (!t.character(')', false)) {
 			l->modifier = parse_expression(ctx, t);
-			add_node(ctx, l->modifier);
 		}
 		t.character(')');
 		
@@ -1699,13 +1624,11 @@ namespace gjs {
 		ast_node* l = new ast_node();
 		l->type = ast_node::node_type::while_loop;
 		l->src(t, start);
-		add_node(ctx, l);
 		ctx.frames.push_back(parse_frame());
 		ctx.node_path.push(l);
 
 		t.character('(');
 		l->condition = parse_expression(ctx, t);
-		add_node(ctx, l->condition);
 		t.character(')');
 
 		if (t.character('{', false)) {
@@ -1730,7 +1653,6 @@ namespace gjs {
 		ast_node* l = new ast_node();
 		l->type = ast_node::node_type::do_while_loop;
 		l->src(t, start);
-		add_node(ctx, l);
 		ctx.frames.push_back(parse_frame());
 		ctx.node_path.push(l);
 
@@ -1748,7 +1670,6 @@ namespace gjs {
 		t.keyword(true, "while");
 		t.character('(');
 		l->condition = parse_expression(ctx, t);
-		add_node(ctx, l->condition);
 		t.character(')');
 
 		ctx.node_path.pop();
@@ -1761,13 +1682,11 @@ namespace gjs {
 		ast_node* r = new ast_node();
 		r->type = ast_node::node_type::return_statement;
 		r->src(t, start);
-		add_node(ctx, r);
 
 		t.backup_state();
 		if (!t.semicolon(false)) {
 			t.commit_state();
 			r->body = parse_expression(ctx, t);
-			add_node(ctx, r->body);
 		} else t.restore_state();
 
 		return r;
@@ -1781,12 +1700,7 @@ namespace gjs {
 		t.restore_state();
 		if (first) {
 			// declaration
-			if (first == "integer") r = parse_declaration(ctx, t);
-			else if (first == "decimal") r = parse_declaration(ctx, t);
-			else if (first == "string") r = parse_declaration(ctx, t);
-			else if (first == "function") r = parse_declaration(ctx, t);
-			else if (first == "void") r = parse_declaration(ctx, t);
-			else if (first == "const") r = parse_const_declaration(ctx, t);
+			if (first == "const") r = parse_const_declaration(ctx, t);
 			else if (first == "static") r = parse_static_declaration(ctx, t);
 			
 			// statement
@@ -1836,8 +1750,10 @@ namespace gjs {
 					t, first
 				);
 			}
-
-			t.semicolon();
+			bool semicolon_optional = false;
+			if (r->type == ast_node::node_type::function_declaration && r->body) semicolon_optional = true;
+			if (r->type == ast_node::node_type::empty) semicolon_optional = true;
+			t.semicolon(!semicolon_optional);
 			return r;
 		}
 
@@ -1860,11 +1776,6 @@ namespace gjs {
 		t.specify_keyword("do");
 		t.specify_keyword("class");
 		t.specify_keyword("format");
-		t.specify_keyword("integer");
-		t.specify_keyword("decimal");
-		t.specify_keyword("string");
-		t.specify_keyword("function");
-		t.specify_keyword("void");
 		t.specify_keyword("return");
 		t.specify_keyword("this");
 		t.specify_keyword("const");
@@ -1927,8 +1838,6 @@ namespace gjs {
 			t->identifier->type = ast_node::node_type::identifier;
 			t->identifier->set(types[i]->name);
 
-			ctx.root->all_nodes.push_back(t);
-			ctx.root->all_nodes.push_back(t->identifier);
 			ctx.frames[0].type_declarations.push_back(t);
 		}
 
@@ -1940,8 +1849,6 @@ namespace gjs {
 			f->identifier->type = ast_node::node_type::identifier;
 			f->identifier->set(funcs[i]->name);
 
-			ctx.root->all_nodes.push_back(f);
-			ctx.root->all_nodes.push_back(f->identifier);
 			ctx.frames[0].variable_declarations.push_back(f);
 		}
 

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -826,7 +826,9 @@ namespace gjs {
 			"constant",
 			"identifier",
 			"type_identifier",
-			"operation"
+			"operation",
+			"context_type",
+			"context_function"
 		};
 		static const char* op_names[] = {
 			"invalid",
@@ -1916,6 +1918,32 @@ namespace gjs {
 		ctx.root->start.file = file;
 		ctx.node_path.push(ctx.root);
 		ctx.frames.push_back(parse_frame());
+
+		vector<vm_type*> types = env->types()->all();
+		for (u32 i = 0;i < types.size();i++) {
+			ast_node* t = new ast_node();
+			t->type = ast_node::node_type::context_type;
+			t->identifier = new ast_node();
+			t->identifier->type = ast_node::node_type::identifier;
+			t->identifier->set(types[i]->name);
+
+			ctx.root->all_nodes.push_back(t);
+			ctx.root->all_nodes.push_back(t->identifier);
+			ctx.frames[0].type_declarations.push_back(t);
+		}
+
+		vector<vm_function*> funcs = env->all_functions();
+		for (u32 i = 0;i < funcs.size();i++) {
+			ast_node* f = new ast_node();
+			f->type = ast_node::node_type::context_function;
+			f->identifier = new ast_node();
+			f->identifier->type = ast_node::node_type::identifier;
+			f->identifier->set(funcs[i]->name);
+
+			ctx.root->all_nodes.push_back(f);
+			ctx.root->all_nodes.push_back(f->identifier);
+			ctx.frames[0].variable_declarations.push_back(f);
+		}
 
 		ast_node* node = parse_next(ctx, t);
 		ctx.root->body = node;

--- a/src/parse.h
+++ b/src/parse.h
@@ -30,7 +30,9 @@ namespace gjs {
 			constant,
 			identifier,
 			type_identifier,
-			operation
+			operation,
+			context_type,
+			context_function
 		};
 		enum class constant_type {
 			none,

--- a/src/parse.h
+++ b/src/parse.h
@@ -102,7 +102,6 @@ namespace gjs {
 
 		ast_node* data_type;
 		ast_node* identifier;
-		ast_node* literal;
 
 		ast_node* body;
 		ast_node* else_body;
@@ -147,12 +146,6 @@ namespace gjs {
 		operation_type op;
 		bool is_const;
 		bool is_static;
-
-
-		// only used for destruction of the ast
-		// should only be populated on the root
-		// node
-		std::vector<ast_node*> all_nodes;
 	};
 
 	class vm_context;

--- a/src/parse_utils.cpp
+++ b/src/parse_utils.cpp
@@ -3,43 +3,6 @@
 using namespace std;
 
 namespace gjs {
-	vector<string> split(const string& str, const string& delimiters) {
-		vector<string> out;
-
-		string cur;
-		bool lastWasDelim = false;
-		for(size_t i = 0;i < str.length();i++) {
-			bool isDelim = false;
-			for(unsigned char d = 0;d < delimiters.length() && !isDelim;d++) {
-				isDelim = str[i] == delimiters[d];
-			}
-
-			if (isDelim) {
-				if (!lastWasDelim) {
-					out.push_back(cur);
-					cur = "";
-					lastWasDelim = true;
-				}
-				continue;
-			}
-
-			cur += str[i];
-			lastWasDelim = false;
-		}
-
-		if (cur.length() > 0) out.push_back(cur);
-		return out;
-	}
-
-	string format(const char* fmt, ...) {
-		va_list l;
-		va_start(l, fmt);
-		char out[1024] = { 0 };
-		vsnprintf(out, 1024, fmt, l);
-		va_end(l);
-		return out;
-	}
-
 	parse_exception::parse_exception(const std::string& _file, const string& _text, const string& _lineText, u32 _line, u32 _col) {
 		file = _file;
 		text = _text;

--- a/src/parse_utils.h
+++ b/src/parse_utils.h
@@ -1,13 +1,11 @@
 #pragma once
 #include <types.h>
+#include <util.h>
 #include <string>
 #include <stack>
 #include <vector>
 
 namespace gjs {
-	std::vector<std::string> split(const std::string& str, const std::string& delimiters);
-	std::string format(const char* fmt, ...);
-
 	class tokenizer {
 		public:
 			tokenizer(const std::string& input);

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -1,0 +1,35 @@
+#include <pipeline.h>
+#include <parse.h>
+#include <compile.h>
+#include <context.h>
+
+namespace gjs {
+	pipeline::pipeline(vm_context* ctx) : m_ctx(ctx) {
+	}
+
+	pipeline::~pipeline() {
+	}
+
+	void pipeline::compile(const std::string& file, const std::string& code) {
+		ast_node* ast = parse_source(m_ctx, file, code);
+		for (u8 i = 0;i < m_ast_steps.size();i++) {
+			m_ast_steps[i](m_ctx, ast);
+		}
+
+		u32 new_code_starts_at = m_ctx->code()->size();
+		compile_ast(m_ctx, ast, m_ctx->code(), m_ctx->map());
+		for (u8 i = 0;i < m_ir_steps.size();i++) {
+			m_ir_steps[i](m_ctx, *m_ctx->code(), m_ctx->map(), new_code_starts_at);
+		}
+
+		delete ast;
+	}
+
+	void pipeline::add_ir_step(ir_step_func step) {
+		m_ir_steps.push_back(step);
+	}
+
+	void pipeline::add_ast_step(ast_step_func step) {
+		m_ast_steps.push_back(step);
+	}
+};

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <types.h>
+
+namespace gjs {
+	class vm_context;
+	class instruction_array;
+	class source_map;
+	struct ast_node;
+	class pipeline {
+		public:
+			typedef void (*ir_step_func)(vm_context* ctx, instruction_array&, source_map*, u32);
+			typedef void (*ast_step_func)(vm_context* ctx, ast_node*);
+
+			pipeline(vm_context* ctx);
+			~pipeline();
+
+			/*
+			 * 1. Parses the source code and generates an abstract syntax tree
+			 * 2. Executes all of the AST steps on the generated tree (in the order they were added)
+			 * 3. Generates the source map and intermediate representation (VM code/instruction_array) code from the AST
+			 * 4. Executes all of the IR steps on the generated IR code (in the order they were added)
+			 *
+			 * This function may throw the following exceptions:
+			 *	- parse_exception
+			 *	- compile_exception
+			 *	- any exceptions thrown by the ir steps or ast steps
+			 */
+			void compile(const std::string& file, const std::string& code);
+
+			/*
+			 * Takes IR code holder and source map as parameters, and modifies them in some way. Typically
+			 * would do some kind of optimization.
+			 *
+			 * Any added/removed instructions must also result in the addition or removal of the related
+			 * source map data
+			 */
+			void add_ir_step(ir_step_func step);
+
+			/*
+			 * Takes the root of the AST as a parameter, and modifies it in some way. Typically would do
+			 * some kind of optimization or validation
+			 */
+			void add_ast_step(ast_step_func step);
+
+		protected:
+			vm_context* m_ctx;
+			std::vector<ir_step_func> m_ir_steps;
+			std::vector<ast_step_func> m_ast_steps;
+	};
+};
+

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -4,37 +4,42 @@ using namespace std;
 
 namespace gjs {
 	void source_map::append(ast_node* node) {
+		append(node->start.file, node->start.lineText, node->start.line, node->start.col);
+	}
+
+	void source_map::append(const std::string& file, const std::string& lineText, u32 line, u32 col) {
 		elem e;
 		bool found_file = false;
 		bool found_line = false;
 		for (u16 i = 0;i < files.size();i++) {
-			if (files[i] == node->start.file) {
+			if (files[i] == file) {
 				e.file = i;
 				found_file = true;
 			}
 		}
 		for (u32 i = 0;i < lines.size();i++) {
-			if (lines[i] == node->start.lineText) {
-				e.line = i;
+			if (lines[i] == lineText) {
+				e.lineTextIdx = i;
 				found_line = true;
 			}
 		}
 		if (!found_file) {
 			e.file = files.size();
-			files.push_back(node->start.file);
+			files.push_back(file);
 		}
 		if (!found_line) {
-			e.line = lines.size();
-			lines.push_back(node->start.lineText);
+			e.lineTextIdx = lines.size();
+			lines.push_back(lineText);
 		}
 
-		e.col = node->start.col;
+		e.line = line;
+		e.col = col;
 
 		map.push_back(e);
 	}
 
 	source_map::src_info source_map::get(address addr) {
 		elem e = map[addr];
-		return { files[e.file], lines[e.line], e.line, e.col };
+		return { files[e.file], lines[e.lineTextIdx], e.line, e.col };
 	}
 };

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -1,0 +1,40 @@
+#include <source_map.h>
+#include <parse.h>
+using namespace std;
+
+namespace gjs {
+	void source_map::append(ast_node* node) {
+		elem e;
+		bool found_file = false;
+		bool found_line = false;
+		for (u16 i = 0;i < files.size();i++) {
+			if (files[i] == node->start.file) {
+				e.file = i;
+				found_file = true;
+			}
+		}
+		for (u32 i = 0;i < lines.size();i++) {
+			if (lines[i] == node->start.lineText) {
+				e.line = i;
+				found_line = true;
+			}
+		}
+		if (!found_file) {
+			e.file = files.size();
+			files.push_back(node->start.file);
+		}
+		if (!found_line) {
+			e.line = lines.size();
+			lines.push_back(node->start.lineText);
+		}
+
+		e.col = node->start.col;
+
+		map.push_back(e);
+	}
+
+	source_map::src_info source_map::get(address addr) {
+		elem e = map[addr];
+		return { files[e.file], lines[e.line], e.line, e.col };
+	}
+};

--- a/src/source_map.h
+++ b/src/source_map.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <types.h>
+
+namespace gjs {
+	struct ast_node;
+
+	struct source_map {
+		std::vector<std::string> files;
+		std::vector<std::string> lines;
+		struct elem {
+			u16 file;
+			u32 line;
+			u32 col;
+		};
+		struct src_info {
+			std::string file;
+			std::string lineText;
+			u32 line;
+			u32 col;
+		};
+
+		// 1:1 map, instruction address : elem
+		std::vector<elem> map;
+
+		void append(ast_node* node);
+
+		src_info get(address addr);
+	};
+};

--- a/src/source_map.h
+++ b/src/source_map.h
@@ -11,6 +11,7 @@ namespace gjs {
 		std::vector<std::string> lines;
 		struct elem {
 			u16 file;
+			u32 lineTextIdx;
 			u32 line;
 			u32 col;
 		};
@@ -25,6 +26,7 @@ namespace gjs {
 		std::vector<elem> map;
 
 		void append(ast_node* node);
+		void append(const std::string& file, const std::string& lineText, u32 line, u32 col);
 
 		src_info get(address addr);
 	};

--- a/src/types.h
+++ b/src/types.h
@@ -9,7 +9,11 @@ namespace gjs {
 	typedef uint32_t	u32;
 	typedef int32_t		i32;
 	typedef uint16_t	u16;
+	typedef int16_t		i16;
 	typedef uint8_t		u8;
+	typedef int8_t		i8;
+	typedef float		f32;
+	typedef double		f64;
 
 	typedef uint64_t	instruction;
 	typedef uint32_t	address;

--- a/src/types.h
+++ b/src/types.h
@@ -15,5 +15,6 @@ namespace gjs {
 	typedef uint32_t	address;
 	typedef float		decimal;
 	typedef int32_t		integer;
+	typedef uint32_t	uinteger;
 	typedef int16_t		memory_offset;
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,42 @@
+#include <stdarg.h>
+#include <util.h>
+using namespace std;
+
+namespace gjs {
+	vector<string> split(const string& str, const string& delimiters) {
+		vector<string> out;
+
+		string cur;
+		bool lastWasDelim = false;
+		for(size_t i = 0;i < str.length();i++) {
+			bool isDelim = false;
+			for(unsigned char d = 0;d < delimiters.length() && !isDelim;d++) {
+				isDelim = str[i] == delimiters[d];
+			}
+
+			if (isDelim) {
+				if (!lastWasDelim) {
+					out.push_back(cur);
+					cur = "";
+					lastWasDelim = true;
+				}
+				continue;
+			}
+
+			cur += str[i];
+			lastWasDelim = false;
+		}
+
+		if (cur.length() > 0) out.push_back(cur);
+		return out;
+	}
+
+	string format(const char* fmt, ...) {
+		va_list l;
+		va_start(l, fmt);
+		char out[1024] = { 0 };
+		vsnprintf(out, 1024, fmt, l);
+		va_end(l);
+		return out;
+	}
+};

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <vector>
+#include <string>
+
+namespace gjs {
+	std::vector<std::string> split(const std::string& str, const std::string& delimiters);
+	std::string format(const char* fmt, ...);
+};
+

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -64,7 +64,7 @@ namespace gjs {
 		while ((*ip) <= cs && !term) {
 			i = code[*ip];
 			if (m_ctx->log_instructions()) {
-				printf("%2.2d: %s\n", *ip, instruction_to_string(i, &state).c_str());
+				printf("0x%2.2x: %s\n", *ip, instruction_to_string(i, &state).c_str());
 			}
 
 			vmi instr = decode_instruction(i);
@@ -402,6 +402,11 @@ namespace gjs {
 					GR64(_O1) = GR64(_O2) << _O3i;
                     break;
                 }
+				// shift bits of immediate left by register value	slir	(dest)	(a)		4		dest = 4 << a
+				case vmi::slir: {
+					GR64(_O1) = _O3i << GR64(_O2);
+					break;
+				}
                 // shift bits right by amount from register			sr		(dest)	(a)		(b)		dest = a >> b
                 case vmi::sr: {
 					GR64(_O1) = GR64(_O2) >> GR64(_O3);
@@ -412,50 +417,175 @@ namespace gjs {
 					GR64(_O1) = GR64(_O2) >> _O3i;
                     break;
                 }
+				// shift bits of immediate right by register value	sri		(dest)	(a)		4		dest = 4 >> a
+				case vmi::srir: {
+					GR64(_O1) = _O3i >> GR64(_O2);
+					break;
+				}
+				// check if register less than register				lt		(dest)	(a)		(b)		dest = a < b
+				case vmi::lt: {
+					GR64(_O1) = GRi(_O2) < GRi(_O3);
+					break;
+				}
+				// check if register less than immediate			lti		(dest)	(a)		1		dest = a < 1
+				case vmi::lti: {
+					GR64(_O1) = GRi(_O2) < _O3i;
+					break;
+				}
+				// check if register less than or equal register	lte		(dest)	(a)		(b)		dest = a <= b
+				case vmi::lte: {
+					GR64(_O1) = GRi(_O2) <= GRi(_O3);
+					break;
+				}
+				// check if register less than or equal immediate	ltei	(dest)	(a)		1		dest = a <= 1
+				case vmi::ltei: {
+					GR64(_O1) = GRi(_O2) <= _O3i;
+					break;
+				}
+				// check if register greater than register			gt		(dest)	(a)		(b)		dest = a > b
+				case vmi::gt: {
+					GR64(_O1) = GRi(_O2) > GRi(_O3);
+					break;
+				}
+				// check if register greater than immediate			gti		(dest)	(a)		1		dest = a > 1
+				case vmi::gti: {
+					GR64(_O1) = GRi(_O2) > _O3i;
+					break;
+				}
+				// check if register greater than or equal register	gte		(dest)	(a)		(b)		dest = a >= b
+				case vmi::gte: {
+					GR64(_O1) = GRi(_O2) >= GRi(_O3);
+					break;
+				}
+				// check if register greater than or equal imm.		gtei	(dest)	(a)		1		dest = a >= 1
+				case vmi::gtei: {
+					GR64(_O1) = GRi(_O2) >= _O3i;
+					break;
+				}
+				// check if register equal register					cmp		(dest)	(a)		(b)		dest = a == b
+				case vmi::cmp: {
+					GR64(_O1) = GRi(_O2) == GRi(_O3);
+					break;
+				}
+				// check if register equal immediate				cmpi	(dest)	(a)		1		dest = a == 1
+				case vmi::cmpi: {
+					GR64(_O1) = GRi(_O2) == _O3i;
+					break;
+				}
+				// check if register not equal register				ncmp	(dest)	(a)		(b)		dest = a != b
+				case vmi::ncmp: {
+					GR64(_O1) = GRi(_O2) != GRi(_O3);
+					break;
+				}
+				// check if register not equal immediate			ncmpi	(dest)	(a)		1		dest = a != 1
+				case vmi::ncmpi: {
+					GR64(_O1) = GRi(_O2) != _O3i;
+					break;
+				}
+				// check if register less than register				flt		(dest)	(a)		(b)		dest = a < b
+				case vmi::flt: {
+					GR64(_O1) = GRd(_O2) < GRd(_O3);
+					break;
+				}
+				// check if register less than immediate			flti	(dest)	(a)		1.0		dest = a < 1.0
+				case vmi::flti: {
+					GR64(_O1) = GRd(_O2) < _O3f;
+					break;
+				}
+				// check if register less than or equal register	flte	(dest)	(a)		(b)		dest = a <= b
+				case vmi::flte: {
+					GR64(_O1) = GRd(_O2) <= GRd(_O3);
+					break;
+				}
+				// check if register less than or equal immediate	fltei	(dest)	(a)		1.0		dest = a <= 1.0
+				case vmi::fltei: {
+					GR64(_O1) = GRd(_O2) <= _O3f;
+					break;
+				}
+				// check if register greater than register			fgt		(dest)	(a)		(b)		dest = a > b
+				case vmi::fgt: {
+					GR64(_O1) = GRd(_O2) > GRd(_O3);
+					break;
+				}
+				// check if register greater than immediate			fgti	(dest)	(a)		1.0		dest = a > 1.0
+				case vmi::fgti: {
+					GR64(_O1) = GRd(_O2) > _O3f;
+					break;
+				}
+				// check if register greater than or equal register	fgte	(dest)	(a)		(b)		dest = a >= b
+				case vmi::fgte: {
+					GR64(_O1) = GRd(_O2) >= GRd(_O3);
+					break;
+				}
+				// check if register greater than or equal imm.		fgtei	(dest)	(a)		1.0		dest = a >= 1.0
+				case vmi::fgtei: {
+					GR64(_O1) = GRd(_O2) >= _O3f;
+					break;
+				}
+				// check if register equal register					fcmp	(dest)	(a)		(b)		dest = a == b
+				case vmi::fcmp: {
+					GR64(_O1) = GRd(_O2) == GRd(_O3);
+					break;
+				}
+				// check if register equal immediate				fcmpi	(dest)	(a)		1.0		dest = a == 1.0
+				case vmi::fcmpi: {
+					GR64(_O1) = GRd(_O2) == _O3f;
+					break;
+				}
+				 // check if register not equal register				fncmp	(dest)	(a)		(b)		dest = a != b
+				case vmi::fncmp: {
+					GR64(_O1) = GRd(_O2) != GRd(_O3);
+					break;
+				}
+				// check if register not equal immediate			fncmpi	(dest)	(a)		1.0		dest = a != 1.0
+				case vmi::fncmpi: {
+					GR64(_O1) = GRd(_O2) != _O3f;
+					break;
+				}
                 // branch if register equals zero					beqz	(a)		(fail_addr)		if a: goto fail_addr
                 case vmi::beqz: {
-					if(GRi(_O1)) *ip = _O2i - 1;
+					if(GRi(_O1)) *ip = _O2ui - 1;
                     break;
                 }
                 // branch if register not equals zero				bneqz	(a)		(fail_addr)		if !a: goto fail_addr
                 case vmi::bneqz: {
-					if(!GRi(_O1)) *ip = _O2i - 1;
+					if(!GRi(_O1)) *ip = _O2ui - 1;
                     break;
                 }
                 // branch if register greater than zero				bgtz	(a)		(fail_addr)		if a <= 0: goto fail_addr
                 case vmi::bgtz: {
-					if(GRi(_O1) <= 0) *ip = _O2i - 1;
+					if(GRi(_O1) <= 0) *ip = _O2ui - 1;
                     break;
                 }
                 // branch if register greater than or equals zero	bgtez	(a)		(fail_addr)		if a < 0: goto fail_addr
                 case vmi::bgtez: {
-					if(GRi(_O1) < 0) *ip = _O2i - 1;
+					if(GRi(_O1) < 0) *ip = _O2ui - 1;
                     break;
                 }
                 // branch if register less than zero				bltz	(a)		(fail_addr)		if a >= 0: goto fail_addr
                 case vmi::bltz: {
-					if(GRi(_O1) >= 0) *ip = _O2i - 1;
+					if(GRi(_O1) >= 0) *ip = _O2ui - 1;
                     break;
                 }
                 // branch if register less than or equals zero		bltez	(a)		(fail_addr)		if a > 0: goto fail_addr
                 case vmi::bltez: {
-					if(GRi(_O1) > 0) *ip = _O2i - 1;
+					if(GRi(_O1) > 0) *ip = _O2ui - 1;
                     break;
                 }
                 // jump to address									jmp		0x123					$ip = 0x123
                 case vmi::jmp: {
-					*ip = _O1i - 1;
+					*ip = _O1ui - 1;
                     break;
                 }
                 // jump to address in register						jmp		(a)						$ip = a
                 case vmi::jmpr: {
-					*ip = GRi(_O1) - 1;
+					*ip = GRx(_O1, u64) - 1;
                     break;
                 }
                 // jump to address and store $ip in $ra				jal		0x123					$ra = $ip + 1;$ip = 0x123
                 case vmi::jal: {
 					u64 addr = _O1ui64;
-					GRi(vmr::ra) = (*ip) + 1;
+					GRx(vmr::ra, u64) = (*ip) + 1;
 					if (addr < code.size()) {
 						*ip = addr - 1;
 					} else call_external(addr);
@@ -463,8 +593,8 @@ namespace gjs {
                 }
                 // jump to address in register and store $ip in $ra	jalr	(a)						$ra = $ip + 1;$ip = a
                 case vmi::jalr: {
-					GRi(vmr::ra) = (*ip) + 1;
-					*ip = GRi(_O1) - 1;
+					GRx(vmr::ra, u64) = (*ip) + 1;
+					*ip = GRx(_O1, u64) - 1;
                     break;
                 }
 				case vmi::instruction_count: {

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -33,10 +33,13 @@ namespace gjs {
 	#define GR64(r) GRx(r, u64)
 	#define _O1 decode_operand_1(i)
 	#define _O1i decode_operand_1i(i)
+	#define _O1ui decode_operand_1ui(i)
 	#define _O2 decode_operand_2(i)
 	#define _O2i decode_operand_2i(i)
+	#define _O2ui decode_operand_2ui(i)
 	#define _O3 decode_operand_3(i)
 	#define _O3i decode_operand_3i(i)
+	#define _O3ui decode_operand_3ui(i)
 	#define _O3f decode_operand_3f(i)
 
 	vm::vm(vm_context* ctx, vm_allocator* allocator, u32 stack_size, u32 mem_size) : m_ctx(ctx), alloc(allocator), state(mem_size), m_stack_size(stack_size) {
@@ -48,10 +51,10 @@ namespace gjs {
 	void vm::execute(const instruction_array& code, address entry) {
 		jit(code);
 		
-		GRi(vmr::ip) = (integer)entry;
-		GRi(vmr::ra) = 0;
-		GRi(vmr::sp) = 0;
-		GRi(vmr::zero) = 0;
+		GR64(vmr::ip) = (integer)entry;
+		GR64(vmr::ra) = 0;
+		GR64(vmr::sp) = 0;
+		GR64(vmr::zero) = 0;
 
 		instruction i;
 		integer* ip = &GRi(vmr::ip);
@@ -67,89 +70,100 @@ namespace gjs {
                 case vmi::null: {
                 	break;
                 }
-				// this is only here to keep the switch cases tight
 				case vmi::term: {
 					term = true;
 					break;
 				}
                 // load 1 byte from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld8: {
-					integer offset = GRi(integer(_O2)) + _O3i;
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u8* ptr = nullptr;
 					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					GR8(_O1) = *(u8*)state.memory[offset];
+						// maybe do some kind of checking
+						ptr = (u8*)offset;
+					} else ptr = (u8*)state.memory[offset];
+					GR64(_O1) = *(u8*)ptr;
                     break;
                 }
                 // load 2 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld16: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size() - 2) {
-						// exception
-						break;
-					}
-					GR16(_O1) = *(u16*)state.memory[offset];
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u16* ptr = nullptr;
+					if (offset < 0 || offset >= state.memory.size()) {
+						// maybe do some kind of checking
+						ptr = (u16*)offset;
+					} else ptr = (u16*)state.memory[offset];
+					GR64(_O1) = *(u16*)ptr;
                     break;
                 }
                 // load 4 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld32: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size() - 4) {
-						// exception
-						break;
-					}
-					GR32(_O1) = *(u32*)state.memory[offset];
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u32* ptr = nullptr;
+					if (offset < 0 || offset >= state.memory.size()) {
+						// maybe do some kind of checking
+						ptr = (u32*)offset;
+					} else ptr = (u32*)state.memory[offset];
+					GR64(_O1) = *(u32*)ptr;
                     break;
                 }
                 // load 8 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld64: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size() - 8) {
-						// exception
-						break;
-					}
-					GR64(_O1) = *(u64*)state.memory[offset];
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u64* ptr = nullptr;
+					if (offset < 0 || offset >= state.memory.size()) {
+						// maybe do some kind of checking
+						ptr = (u64*)offset;
+					} else ptr = (u64*)state.memory[offset];
+					GR64(_O1) = *(u64*)ptr;
                     break;
                 }
                 // store 1 byte in memory from register				store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st8: {
-					integer offset = GRi(integer(_O2)) + _O3i;
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u8* ptr = nullptr;
 					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u8*)state.memory[offset]) = GR8(_O1);
+						// maybe do some kind of checking
+						ptr = (u8*)offset;
+					} else ptr = (u8*)state.memory[offset];
+					*ptr = GR8(_O1);
                     break;
                 }
                 // store 2 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st16: {
-					integer offset = GRi(integer(_O2)) + _O3i;
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u16* ptr = nullptr;
 					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u16*)state.memory[offset]) = GR16(_O1);
+						// maybe do some kind of checking
+						ptr = (u16*)offset;
+					} else ptr = (u16*)state.memory[offset];
+					*ptr = GR16(_O1);
                     break;
                 }
                 // store 4 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st32: {
-					integer offset = GRi(integer(_O2)) + _O3i;
+					vmr reg = _O2;
+					u64 o1 = GR64(integer(reg));
+					u64 o2 = _O3i;
+					u64 o3 = _O3ui;
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u32* ptr = nullptr;
 					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u32*)state.memory[offset]) = GR32(_O1);
+						// maybe do some kind of checking
+						ptr = (u32*)offset;
+					} else ptr = (u32*)state.memory[offset];
+					*ptr = GR32(_O1);
                     break;
                 }
                 // store 8 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st64: {
-					integer offset = GRi(integer(_O2)) + _O3i;
+					u64 offset = GR64(integer(_O2)) + _O3i;
+					u64* ptr = nullptr;
 					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u64*)state.memory[offset]) = GR64(_O1);
+						// maybe do some kind of checking
+						ptr = (u64*)offset;
+					} else ptr = (u64*)state.memory[offset];
+					*ptr = GR64(_O1);
                     break;
                 }
                 // push register onto stack							push	(a)						*sp = a; sp--
@@ -187,54 +201,104 @@ namespace gjs {
 				}
                 // add two registers								add		(dest)	(a)		(b)		dest = a + b
                 case vmi::add: {
-					GRi(_O1) = GRi(_O2) + GRi(_O3);
+					GRx(_O1, i64) = GRx(_O2, i64) + GRx(_O3, i64);
                     break;
                 }
                 // add register and immediate value					addi	(dest)	(a)		1.0		dest = a + 1
                 case vmi::addi: {
-					GRi(_O1) = GRi(_O2) + _O3i;
+					GRx(_O1, i64) = GRx(_O2, i64) + _O3i;
 					break;
                 }
                 // subtract register from another					sub		(dest)	(a)		(b)		dest = a - b
                 case vmi::sub: {
-					GRi(_O1) = GRi(_O2) - GRi(_O3);
+					GRx(_O1, i64) = GRx(_O2, i64) - GRx(_O3, i64);
                     break;
                 }
                 // subtract immediate value from register			subi	(dest)	(a)		1.0		dest = a - 1
                 case vmi::subi: {
-					GRi(_O1) = GRi(_O2) - _O3i;
+					GRx(_O1, i64) = GRx(_O2, i64) - _O3i;
                     break;
                 }
                 // subtract register from immediate value			subir	(dest)	(a)		1.0		dest = 1 - a
                 case vmi::subir: {
-					GRi(_O1) = _O3i - GRi(_O2);
+					GRx(_O1, i64) = _O3i - GRx(_O2, i64);
                     break;
                 }
                 // multiply two registers							mul		(dest)	(a)		(b)		dest = a * b
                 case vmi::mul: {
-					GRi(_O1) = GRi(_O2) * GRi(_O3);
+					GRx(_O1, i64) = GRx(_O2, i64) * GRi(_O3);
                     break;
                 }
                 // multiply register and immediate value			muli	(dest)	(a)		1.0		dest = a * 1
                 case vmi::muli: {
-					GRi(_O1) = GRi(_O2) * _O3i;
+					GRx(_O1, i64) = GRx(_O2, i64) * _O3i;
                     break;
                 }
                 // divide register by another						div		(dest)	(a)		(b)		dest = a / b
                 case vmi::div: {
-					GRi(_O1) = GRi(_O2) / GRi(_O3);
+					GRx(_O1, i64) = GRx(_O2, i64) / GRx(_O3, i64);
                     break;
                 }
                 // divide register by immediate value				divi	(dest)	(a)		1.0		dest = a / 1
                 case vmi::divi: {
-					GRi(_O1) = GRi(_O2) / _O3i;
+					GRx(_O1, i64) = GRx(_O2, i64) / _O3i;
                     break;
                 }
                 // divide immediate value by register				divir	(dest)	(a)		1.0		dest = 1 / a
                 case vmi::divir: {
-					GRi(_O1) = _O3i / GRi(_O2);
+					GRx(_O1, i64) = _O3i / GRx(_O2, i64);
                     break;
                 }
+							   // add two registers								add		(dest)	(a)		(b)		dest = a + b
+				case vmi::addu: {
+					GRx(_O1, u64) = GRx(_O2, u64) + GRx(_O3, u64);
+					break;
+				}
+							 // add register and immediate value					addi	(dest)	(a)		1.0		dest = a + 1
+				case vmi::addui: {
+					GRx(_O1, u64) = GRx(_O2, u64) + _O3ui;
+					break;
+				}
+							  // subtract register from another					sub		(dest)	(a)		(b)		dest = a - b
+				case vmi::subu: {
+					GRx(_O1, u64) = GRx(_O2, u64) - GRx(_O3, u64);
+					break;
+				}
+							 // subtract immediate value from register			subi	(dest)	(a)		1.0		dest = a - 1
+				case vmi::subui: {
+					GRx(_O1, u64) = GRx(_O2, u64) - _O3ui;
+					break;
+				}
+							  // subtract register from immediate value			subir	(dest)	(a)		1.0		dest = 1 - a
+				case vmi::subuir: {
+					GRx(_O1, u64) = _O3ui - GRx(_O2, u64);
+					break;
+				}
+							   // multiply two registers							mul		(dest)	(a)		(b)		dest = a * b
+				case vmi::mulu: {
+					GRx(_O1, u64) = GRx(_O2, u64) * GRx(_O3, u64);
+					break;
+				}
+							 // multiply register and immediate value			muli	(dest)	(a)		1.0		dest = a * 1
+				case vmi::mului: {
+					GRx(_O1, u64) = GRx(_O2, u64) * _O3ui;
+					break;
+				}
+							  // divide register by another						div		(dest)	(a)		(b)		dest = a / b
+				case vmi::divu: {
+					GRx(_O1, u64) = GRx(_O2, u64) / GRx(_O3, u64);
+					break;
+				}
+							 // divide register by immediate value				divi	(dest)	(a)		1.0		dest = a / 1
+				case vmi::divui: {
+					GRx(_O1, u64) = GRx(_O2, u64) / _O3ui;
+					break;
+				}
+							  // divide immediate value by register				divir	(dest)	(a)		1.0		dest = 1 / a
+				case vmi::divuir: {
+					GRx(_O1, u64) = _O3ui / GRx(_O2, u64);
+					break;
+				}
                 // add two registers								add		(dest)	(a)		(b)		dest = a + b
 				case vmi::fadd: {
 					GRd(_O1) = GRd(_O2) + GRd(_O3);
@@ -413,360 +477,5 @@ namespace gjs {
 	}
 
 	void vm::jit(const instruction_array& code) {
-		/*
-
-		CodeHolder h;
-		x86::Compiler c(&h);
-		c.newFunc(FuncSignatureT<void>(CallConv::kIdCDecl));
-
-		for (u32 ip = 0;ip < code.size();ip++) {
-			instruction i = code[ip];
-			vmi instr = decode_instruction(i);
-			switch (instr) {
-				// do nothing
-                case vmi::null: {
-                	break;
-                }
-				// this is only here to keep the switch cases tight
-				case vmi::term: {
-					break;
-				}
-                // load 1 byte from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
-                case vmi::ld8: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					GR8(_O1) = *(u8*)state.memory[offset];
-                    break;
-                }
-                // load 2 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
-                case vmi::ld16: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size() - 2) {
-						// exception
-						break;
-					}
-					GR16(_O1) = *(u16*)state.memory[offset];
-                    break;
-                }
-                // load 4 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
-                case vmi::ld32: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size() - 4) {
-						// exception
-						break;
-					}
-					GR32(_O1) = *(u32*)state.memory[offset];
-                    break;
-                }
-                // load 8 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
-                case vmi::ld64: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size() - 8) {
-						// exception
-						break;
-					}
-					GR64(_O1) = *(u64*)state.memory[offset];
-                    break;
-                }
-                // store 1 byte in memory from register				store	(src)	(dest)	10		dest = *(src + 10)
-                case vmi::st8: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u8*)state.memory[offset]) = GR8(_O1);
-                    break;
-                }
-                // store 2 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
-                case vmi::st16: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u16*)state.memory[offset]) = GR16(_O1);
-                    break;
-                }
-                // store 4 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
-                case vmi::st32: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u32*)state.memory[offset]) = GR32(_O1);
-                    break;
-                }
-                // store 8 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
-                case vmi::st64: {
-					integer offset = GRi(integer(_O2)) + _O3i;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// exception
-						break;
-					}
-					*((u64*)state.memory[offset]) = GR64(_O1);
-                    break;
-                }
-                // push register onto stack							push	(a)						*sp = a; sp--
-                case vmi::push: {
-					integer& offset = GRi(vmr::sp);
-					if (offset - 8 <= 0) {
-						// stack overflow exception
-						break;
-					}
-
-					*((u64*)state.memory[offset]) = GR64(_O1);
-					offset -= 8;
-                    break;
-                }
-                // pop value from the stack into register			pop		(a)						a = *sp; sp++
-                case vmi::pop: {
-					integer& offset = GRi(vmr::sp);
-					if (offset + 8 > m_stack_size) {
-						// stack underflow exception
-						break;
-					}
-					GR64(_O1) = *((u64*)state.memory[offset]);
-					offset += 8;
-                    break;
-                }
-				// move from general register to float register		mtfp	(a)		(b)				b = a
-				case vmi::mtfp: {
-					GR32(_O2) = GR32(_O1);
-					break;
-				}
-				// move from float register to general register		mffp	(a)		(b)				b =	a
-				case vmi::mffp: {
-					GR32(_O2) = GR32(_O1);
-					break;
-				}
-                // add two registers								add		(dest)	(a)		(b)		dest = a + b
-                case vmi::add: {
-					GRi(_O1) = GRi(_O2) + GRi(_O3);
-                    break;
-                }
-                // add register and immediate value					addi	(dest)	(a)		1.0		dest = a + 1
-                case vmi::addi: {
-					GRi(_O1) = GRi(_O2) + _O3i;
-					break;
-                }
-                // subtract register from another					sub		(dest)	(a)		(b)		dest = a - b
-                case vmi::sub: {
-					GRi(_O1) = GRi(_O2) - GRi(_O3);
-                    break;
-                }
-                // subtract immediate value from register			subi	(dest)	(a)		1.0		dest = a - 1
-                case vmi::subi: {
-					GRi(_O1) = GRi(_O2) - _O3i;
-                    break;
-                }
-                // subtract register from immediate value			subir	(dest)	(a)		1.0		dest = 1 - a
-                case vmi::subir: {
-					GRi(_O1) = _O3i - GRi(_O2);
-                    break;
-                }
-                // multiply two registers							mul		(dest)	(a)		(b)		dest = a * b
-                case vmi::mul: {
-					GRi(_O1) = GRi(_O2) * GRi(_O3);
-                    break;
-                }
-                // multiply register and immediate value			muli	(dest)	(a)		1.0		dest = a * 1
-                case vmi::muli: {
-					GRi(_O1) = GRi(_O2) - _O3i;
-                    break;
-                }
-                // divide register by another						div		(dest)	(a)		(b)		dest = a / b
-                case vmi::div: {
-					GRi(_O1) = GRi(_O2) / GRi(_O3);
-                    break;
-                }
-                // divide register by immediate value				divi	(dest)	(a)		1.0		dest = a / 1
-                case vmi::divi: {
-					GRi(_O1) = GRi(_O2) / _O3i;
-                    break;
-                }
-                // divide immediate value by register				divir	(dest)	(a)		1.0		dest = 1 / a
-                case vmi::divir: {
-					GRi(_O1) = _O3i / GRi(_O2);
-                    break;
-                }
-                // add two registers								add		(dest)	(a)		(b)		dest = a + b
-				case vmi::fadd: {
-					GRd(_O1) = GRd(_O2) + GRd(_O3);
-                    break;
-                }
-                // add register and immediate value					faddi	(dest)	(a)		1.0		dest = a + 1.0
-                case vmi::faddi: {
-					GRd(_O1) = GRd(_O2) + _O3f;
-					break;
-                }
-                // subtract register from another					fsub	(dest)	(a)		(b)		dest = a - b
-                case vmi::fsub: {
-					GRd(_O1) = GRd(_O2) - GRd(_O3);
-                    break;
-                }
-                // subtract immediate value from register			fsubi	(dest)	(a)		1.0		dest = a - 1.0
-                case vmi::fsubi: {
-					GRd(_O1) = GRd(_O2) - _O3f;
-                    break;
-                }
-                // subtract register from immediate value			fsubir	(dest)	(a)		1.0		dest = 1.0 - a
-                case vmi::fsubir: {
-					GRd(_O1) = _O3f - GRd(_O2);
-                    break;
-                }
-                // multiply two registers							fmul	(dest)	(a)		(b)		dest = a * b
-                case vmi::fmul: {
-					GRd(_O1) = GRd(_O2) * GRd(_O3);
-                    break;
-                }
-                // multiply register and immediate value			fmuli	(dest)	(a)		1.0		dest = a * 1.0
-                case vmi::fmuli: {
-					GRd(_O1) = GRd(_O2) * _O3f;
-                    break;
-                }
-                // divide register by another						fdiv	(dest)	(a)		(b)		dest = a / b
-                case vmi::fdiv: {
-					GRd(_O1) = GRd(_O2) / GRd(_O3);
-                    break;
-                }
-                // divide register by immediate value				fdivi	(dest)	(a)		1.0		dest = a / 1.0
-                case vmi::fdivi: {
-					GRd(_O1) = GRd(_O2) / _O3f;
-                    break;
-                }
-                // divide immediate value by register				fdivir	(dest)	(a)		1.0		dest = 1.0 / a
-                case vmi::fdivir: {
-					GRd(_O1) = _O3f / GRd(_O2);
-                    break;
-                }
-                // logical and										and		(dest)	(a)		(b)		dest = a && b
-                case vmi::and: {
-					GR64(_O1) = GR64(_O2) && GR64(_O3);
-                    break;
-                }
-                // logical or										or		(dest)	(a)		(b)		dest = a || b
-                case vmi::or: {
-					GR64(_O1) = GR64(_O2) || GR64(_O3);
-                    break;
-                }
-                // bitwise and										band	(dest)	(a)		(b)		dest = a & b
-                case vmi::band: {
-					GR64(_O1) = GR64(_O2) & GR64(_O3);
-                    break;
-                }
-                // bitwise and register and immediate value			bandi	(dest)	(a)		0x0F	dest = a & 0x0F
-                case vmi::bandi: {
-					GR64(_O1) = GR64(_O2) & _O3i;
-                    break;
-                }
-                // bitwise or										bor		(dest)	(a)		(b)		dest = a | b
-                case vmi::bor: {
-					GR64(_O1) = GR64(_O2) | GR64(_O3);
-                    break;
-                }
-                // bitwise or register and immediate value			bori	(dest)	(a)		0x0F	dest = a | 0x0F
-                case vmi::bori: {
-					GR64(_O1) = GR64(_O2) | _O3i;
-                    break;
-                }
-                // exclusive or										xor		(dest)	(a)		(b)		dest = a ^ b
-                case vmi::xor: {
-					GR64(_O1) = GR64(_O2) ^ GR64(_O3);
-                    break;
-                }
-                // exlusive or register and immediate value			xori	(dest)	(a)		0x0F	dest = a ^ 0x0F
-                case vmi::xori: {
-					GR64(_O1) = GR64(_O2) ^ _O3i;
-                    break;
-                }
-                // shift bits left by amount from register			sl		(dest)	(a)		(b)		dest = a << b
-                case vmi::sl: {
-					GR64(_O1) = GR64(_O2) << GR64(_O3);
-                    break;
-                }
-                // shift bits left by immediate value				sli		(dest)	(a)		4		dest = a << 4
-                case vmi::sli: {
-					GR64(_O1) = GR64(_O2) << _O3i;
-                    break;
-                }
-                // shift bits right by amount from register			sr		(dest)	(a)		(b)		dest = a >> b
-                case vmi::sr: {
-					GR64(_O1) = GR64(_O2) >> GR64(_O3);
-                    break;
-                }
-                // shift bits right by immediate value				sri		(dest)	(a)		4		dest = a >> 4
-                case vmi::sri: {
-					GR64(_O1) = GR64(_O2) >> _O3i;
-                    break;
-                }
-                // branch if register equals zero					beqz	(a)		(fail_addr)		if a: goto fail_addr
-                case vmi::beqz: {
-					if(GRi(_O1)) *ip = _O2i;
-                    break;
-                }
-                // branch if register not equals zero				bneqz	(a)		(fail_addr)		if !a: goto fail_addr
-                case vmi::bneqz: {
-					if(!GRi(_O1)) *ip = _O2i;
-                    break;
-                }
-                // branch if register greater than zero				bgtz	(a)		(fail_addr)		if a <= 0: goto fail_addr
-                case vmi::bgtz: {
-					if(GRi(_O1) <= 0) *ip = _O2i;
-                    break;
-                }
-                // branch if register greater than or equals zero	bgtez	(a)		(fail_addr)		if a < 0: goto fail_addr
-                case vmi::bgtez: {
-					if(GRi(_O1) < 0) *ip = _O2i;
-                    break;
-                }
-                // branch if register less than zero				bltz	(a)		(fail_addr)		if a >= 0: goto fail_addr
-                case vmi::bltz: {
-					if(GRi(_O1) >= 0) *ip = _O2i;
-                    break;
-                }
-                // branch if register less than or equals zero		bltez	(a)		(fail_addr)		if a > 0: goto fail_addr
-                case vmi::bltez: {
-					if(GRi(_O1) > 0) *ip = _O2i;
-                    break;
-                }
-                // jump to address									jmp		0x123					$ip = 0x123
-                case vmi::jmp: {
-					*ip = _O1i;
-                    break;
-                }
-                // jump to address in register						jmp		(a)						$ip = a
-                case vmi::jmpr: {
-					*ip = GRi(_O1);
-                    break;
-                }
-                // jump to address and store $ip in $ra				jal		0x123					$ra = $ip + 1;$ip = 0x123
-                case vmi::jal: {
-					GRi(vmr::ra) = (*ip) + 1;
-					*ip = _O1i;
-                    break;
-                }
-                // jump to address in register and store $ip in $ra	jalr	(a)						$ra = $ip + 1;$ip = a
-                case vmi::jalr: {
-					GRi(vmr::ra) = (*ip) + 1;
-					*ip = GRi(_O1);
-                    break;
-                }
-				case vmi::instruction_count: {
-					break;
-				}
-				default: {
-					// exception
-					// deinitialize?
-					break;
-				}
-			}
-		}
-
-		*/
 	}
 };

--- a/src/vm.h
+++ b/src/vm.h
@@ -5,10 +5,10 @@
 
 namespace gjs {
 	class vm_allocator;
-
+	class vm_context;
 	class vm {
 		public:
-			vm(vm_allocator* alloc, u32 stack_size, u32 mem_size);
+			vm(vm_context* ctx, vm_allocator* alloc, u32 stack_size, u32 mem_size);
 			~vm();
 
 			void execute(const instruction_array& code, address entry);
@@ -18,6 +18,7 @@ namespace gjs {
 
 		protected:
 			void jit(const instruction_array& code);
+			vm_context* m_ctx;
 			u32 m_stack_size;
 	};
 };

--- a/src/vm.h
+++ b/src/vm.h
@@ -17,6 +17,8 @@ namespace gjs {
 			vm_state state;
 
 		protected:
+			friend class vm_function;
+			void call_external(u64 addr);
 			void jit(const instruction_array& code);
 			vm_context* m_ctx;
 			u32 m_stack_size;


### PR DESCRIPTION
- Unified interface for host and script functions and types with `vm_function` and `vm_type` classes
- Cleaned up and optimized binding utilities a bunch
- Created easy to use interface in `vm_context` for binding host functions, structures, classes
- Moved `source_map` to its own `.h/.cpp` files
- Moved ownership of source map, asmjit runtime, allocator to `vm_context`
- Added `pipeline` class to manage all phases of compiling raw source to IR (and maybe soon native code) and execute custom steps after each phase (for optimizations, validation steps)
- Moved base `integer`, `decimal`, `string`, `void` types out of parsing, compilation logic and replaced with `func::var::is_floating_point`, `func::var::is_builtin`, `func::var::is_unsigned` in the compiler
- Renamed `integer`, `decimal` to `i32` and `f32`
- Added more builtin data types (`u8`, `u16`, `u32`, `u64`, `i8`, `i16`, `i64`, `f64`, `bool`)
- Builtin data types are now created using `vm_type`
- Added `runtime_exception` class
- Added `add_code` method to `vm_context` for running source through the `pipeline` and including the new code in the context
- Added `default_steps.h/.cpp` for holding basic optimization and validation steps to `pipeline`
- Added unsigned arithmetic instructions
- Added `slir`, `srir` instructions which were missing before
- Changed encoded `jmp`, `jal` addresses to 57-bit integers from 32-bit integers
- Moved commonly used `format` function from `parse_utils.h/.cpp` to `util.h/.cpp` (Also `strip`)
- Added `call_external` to `vm` class for calling functions associated with `jal` addresses not within the context (host functions)