### PR TITLE
Once again, more than the branch name implies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bin/
 build/
 *.vcxproj
 *.filters
@@ -13,3 +12,6 @@ x64/
 *.editorconfig
 *.yml
 .vs/
+*.exe
+*.ilk
+*.pdb

--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -1,29 +1,4 @@
-format fmt = { a: f32, b: i32, c: u32 };
-class vec3 {
-    constructor (f32 x, f32 y, f32 z) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-    }
-    destructor () {
-        dtestvec(this);
-    }
-    
-    vec3 operator + (vec3 r) {
-        return vec3(this.x + r.x, this.y + r.y, this.z + r.z);
-    }
-    
-    void operator = (vec3 r) {
-        this.x = r.x;
-        this.y = r.y;
-        this.z = r.z;
-    }
-    
-    f32 x;
-    f32 y;
-    f32 z;
-};
 
 void it() {
-    testvec(vec3(0.0, 1.0, 2.0) + vec3(2.0, 1.0, 0.0));
+    foo.s = 1.5;
 }

--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -57,3 +57,10 @@ i32 main(foo a) {
     pf(a);
     return a.t(test1(100), a.x);
 };
+void it() {
+    foo a = new foo(0);
+    delete a;
+    vec3 b = new vec3(1.0, 2.0, 3.5);
+    delete b;
+    return;
+}

--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -4,15 +4,10 @@ class vec3 {
         this.x = x;
         this.y = y;
         this.z = z;
-        testvec(this);
-        return this;
     }
     
-    vec3 operator += (vec3 r) {
-        this.x += r.x;
-        this.y += r.y;
-        this.z += r.z;
-        return this;
+    vec3 operator + (vec3 r) {
+        return new vec3(this.x + r.x, this.y + r.y, this.z + r.z);
     }
     
     f32 x;
@@ -20,47 +15,8 @@ class vec3 {
     f32 z;
 };
 
-i32 test(i32 x);
-i32 something(i32 arg0, i32 arg1, i32 arg2) {
-    i32 x = arg0 + arg1 * 4.0;
-    i32 y = x - arg2;
-    x = y++;
-    for (i32 i = 0;i < 10;i++) {
-        x += 3;
-    }
-    return test(x);
-}
-i32 test(i32 x) {
-    return x > 5 ? x * 5 : x;
-}
-void pf(foo f) {
-    print_foo(f);
-    return;
-}
-i32 test1(i32 z) {
-    foo a = new foo(0);
-    vec3 b = new vec3(1.0, 2.0, 3.5);
-    testvec(b);
-    a.w = b.z;
-    pf(a);
-    delete a;
-    testvec(b);
-    delete b;
-    return something(z, z + 1, z + 2);
-}
-i32 main(foo a) {
-    a.x = 52;
-    a.y *= 5;
-    a.z = (6 / 3);
-    a.w = 61.69;
-    a.x = a;
-    pf(a);
-    return a.t(test1(100), a.x);
-};
 void it() {
-    foo a = new foo(0);
-    delete a;
-    vec3 b = new vec3(1.0, 2.0, 3.5);
-    delete b;
-    return;
+    vec3 a = new vec3(1.0, 2.0, 3.0);
+    vec3 b = new vec3(3.0, 2.0, 1.0);
+    testvec(a + b);
 }

--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -1,0 +1,59 @@
+format fmt = { a: f32, b: i32, c: u32 };
+class vec3 {
+    constructor (f32 x, f32 y, f32 z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        testvec(this);
+        return this;
+    }
+    
+    vec3 operator += (vec3 r) {
+        this.x += r.x;
+        this.y += r.y;
+        this.z += r.z;
+        return this;
+    }
+    
+    f32 x;
+    f32 y;
+    f32 z;
+};
+
+i32 test(i32 x);
+i32 something(i32 arg0, i32 arg1, i32 arg2) {
+    i32 x = arg0 + arg1 * 4.0;
+    i32 y = x - arg2;
+    x = y++;
+    for (i32 i = 0;i < 10;i++) {
+        x += 3;
+    }
+    return test(x);
+}
+i32 test(i32 x) {
+    return x > 5 ? x * 5 : x;
+}
+void pf(foo f) {
+    print_foo(f);
+    return;
+}
+i32 test1(i32 z) {
+    foo a = new foo(0);
+    vec3 b = new vec3(1.0, 2.0, 3.5);
+    testvec(b);
+    a.w = b.z;
+    pf(a);
+    delete a;
+    testvec(b);
+    delete b;
+    return something(z, z + 1, z + 2);
+}
+i32 main(foo a) {
+    a.x = 52;
+    a.y *= 5;
+    a.z = (6 / 3);
+    a.w = 61.69;
+    a.x = a;
+    pf(a);
+    return a.t(test1(100), a.x);
+};

--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -5,9 +5,18 @@ class vec3 {
         this.y = y;
         this.z = z;
     }
+    destructor () {
+        dtestvec(this);
+    }
     
     vec3 operator + (vec3 r) {
-        return new vec3(this.x + r.x, this.y + r.y, this.z + r.z);
+        return vec3(this.x + r.x, this.y + r.y, this.z + r.z);
+    }
+    
+    void operator = (vec3 r) {
+        this.x = r.x;
+        this.y = r.y;
+        this.z = r.z;
     }
     
     f32 x;
@@ -16,7 +25,5 @@ class vec3 {
 };
 
 void it() {
-    vec3 a = new vec3(1.0, 2.0, 3.0);
-    vec3 b = new vec3(3.0, 2.0, 1.0);
-    testvec(a + b);
+    testvec(vec3(0.0, 1.0, 2.0) + vec3(2.0, 1.0, 0.0));
 }

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -73,10 +73,16 @@ namespace gjs {
 	vm_function::vm_function(type_manager* mgr, bind::wrapped_function* wrapped) {
 		m_ctx = mgr->m_ctx;
 		signature.return_loc = vm_register::v0;
+		signature.returns_pointer = wrapped->ret_is_ptr;
 		name = wrapped->name;
 		signature.text = wrapped->sig;
 		for (u8 i = 0;i < wrapped->arg_types.size();i++) {
-			signature.arg_types.push_back(mgr->get(wrapped->arg_types[i].name()));
+			vm_type* atp = nullptr;
+			if (std::string(wrapped->arg_types[i].name()) == "void" && wrapped->ret_is_ptr) {
+				atp = mgr->get("void*");
+			} else atp = mgr->get(wrapped->arg_types[i].name());
+
+			signature.arg_types.push_back(atp);
 			if (!signature.arg_types[i]) {
 				throw bind_exception(format("Arg '%d' of function '%s' is of type '%s' that has not been bound yet", i + 1, name.c_str(), wrapped->arg_types[i].name()));
 			}
@@ -94,7 +100,10 @@ namespace gjs {
 			else signature.arg_locs.push_back(vm_register(integer(last_a) + 1));
 		}
 
-		signature.return_type = mgr->get(wrapped->return_type.name());
+		if (std::string(wrapped->return_type.name()) == "void" && wrapped->ret_is_ptr) {
+			signature.return_type = mgr->get("void*");
+		} else signature.return_type = mgr->get(wrapped->return_type.name());
+
 		if (!signature.return_type) {
 			throw bind_exception(format("Return value of function '%s' is of type '%s' that has not been bound yet", name.c_str(), wrapped->return_type.name()));
 		}

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -68,10 +68,12 @@ namespace gjs {
 		name = _name;
 		access.entry = addr;
 		is_host = false;
+		signature.returns_on_stack = false;
 	}
 
 	vm_function::vm_function(type_manager* mgr, bind::wrapped_function* wrapped) {
 		m_ctx = mgr->m_ctx;
+		signature.returns_on_stack = false;
 		signature.return_loc = vm_register::v0;
 		signature.returns_pointer = wrapped->ret_is_ptr;
 		name = wrapped->name;
@@ -108,8 +110,7 @@ namespace gjs {
 			throw bind_exception(format("Return value of function '%s' is of type '%s' that has not been bound yet", name.c_str(), wrapped->return_type.name()));
 		}
 
-		signature.is_thiscall = wrapped->name.find_first_of(':') != std::string::npos;
-		signature.return_loc = vm_register::v0;
+		signature.is_thiscall = wrapped->name.find_first_of(':') != std::string::npos && !wrapped->is_static_method;
 		access.wrapped = wrapped;
 		mgr->m_ctx->add(this);
 	}

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -84,10 +84,10 @@ namespace gjs {
 				atp = mgr->get("void*");
 			} else atp = mgr->get(wrapped->arg_types[i].name());
 
-			signature.arg_types.push_back(atp);
-			if (!signature.arg_types[i]) {
+			if (!atp) {
 				throw bind_exception(format("Arg '%d' of function '%s' is of type '%s' that has not been bound yet", i + 1, name.c_str(), wrapped->arg_types[i].name()));
 			}
+			signature.arg_types.push_back(atp);
 
 			vm_register last_a = vm_register(integer(vm_register::a0) - 1);
 			vm_register last_f = vm_register(integer(vm_register::f0) - 1);

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -84,9 +84,10 @@ namespace gjs {
 
 		ctx->bind(script_allocate, "alloc");
 		ctx->bind(script_free, "free");
+		ctx->bind(script_copymem, "memcopy");
 	}
 
-	void* script_allocate(u32 size) {
+	void* script_allocate(uinteger size) {
 		// todo: allocate from context memory
 		void* mem = malloc(size);
 		return mem;
@@ -94,5 +95,9 @@ namespace gjs {
 
 	void script_free(void* ptr) {
 		free(ptr);
+	}
+
+	void script_copymem(void* to, void* from, uinteger size) {
+		memmove(to, from, size);
 	}
 };

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -1,0 +1,98 @@
+#include <builtin.h>
+#include <context.h>
+
+namespace gjs {
+	// todo: thread_id:ctx map
+	static vm_context* ctx = nullptr;
+
+	void set_builtin_context(vm_context* _ctx) {
+		ctx = _ctx;
+	}
+
+	void init_context(vm_context* ctx) {
+		vm_type* tp = nullptr;
+		tp = ctx->types()->add("i32", typeid(i32).name());
+		tp->is_primitive = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(i32);
+
+		tp = nullptr;
+		tp = ctx->types()->add("u32", typeid(u32).name());
+		tp->is_primitive = true;
+		tp->is_unsigned = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(u32);
+
+		tp = nullptr;
+		tp = ctx->types()->add("i16", typeid(i16).name());
+		tp->is_primitive = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(i16);
+
+		tp = nullptr;
+		tp = ctx->types()->add("u16", typeid(u16).name());
+		tp->is_primitive = true;
+		tp->is_unsigned = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(u16);
+
+		tp = nullptr;
+		tp = ctx->types()->add("i8", typeid(i8).name());
+		tp->is_primitive = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(i8);
+
+		tp = nullptr;
+		tp = ctx->types()->add("u8", typeid(u8).name());
+		tp->is_primitive = true;
+		tp->is_unsigned = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(u8);
+
+		tp = ctx->types()->add("f32", typeid(f32).name());
+		tp->is_primitive = true;
+		tp->is_floating_point = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(f32);
+
+		tp = ctx->types()->add("f64", typeid(f64).name());
+		tp->is_primitive = true;
+		tp->is_floating_point = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(f64);
+
+		tp = ctx->types()->add("bool", typeid(bool).name());
+		tp->is_primitive = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(bool);
+
+		tp = ctx->types()->add("void", "void");
+		tp->is_primitive = true;
+		tp->is_builtin = true;
+		tp->size = 0;
+
+		tp = ctx->types()->add("data", "void*");
+		tp->is_primitive = false;
+		tp->is_builtin = true;
+		tp->size = sizeof(void*);
+		tp->is_unsigned = true;
+
+		tp = ctx->types()->add("string", "char");
+		tp->is_primitive = false;
+		tp->is_builtin = true;
+		tp->size = sizeof(char*);
+
+		ctx->bind(script_allocate, "alloc");
+		ctx->bind(script_free, "free");
+	}
+
+	void* script_allocate(u32 size) {
+		// todo: allocate from context memory
+		void* mem = malloc(size);
+		return mem;
+	}
+
+	void script_free(void* ptr) {
+		free(ptr);
+	}
+};

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -11,6 +11,22 @@ namespace gjs {
 
 	void init_context(vm_context* ctx) {
 		vm_type* tp = nullptr;
+
+		tp = nullptr;
+		tp = ctx->types()->add("i64", typeid(i64).name());
+		tp->is_primitive = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(i64);
+
+
+		tp = nullptr;
+		tp = ctx->types()->add("u64", typeid(u64).name());
+		tp->is_primitive = true;
+		tp->is_unsigned = true;
+		tp->is_builtin = true;
+		tp->size = sizeof(u64);
+
+		tp = nullptr;
 		tp = ctx->types()->add("i32", typeid(i32).name());
 		tp->is_primitive = true;
 		tp->is_builtin = true;

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -67,7 +67,7 @@ namespace gjs {
 		tp->size = sizeof(bool);
 
 		tp = ctx->types()->add("void", "void");
-		tp->is_primitive = true;
+		tp->is_primitive = false;
 		tp->is_builtin = true;
 		tp->size = 0;
 

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -6,6 +6,7 @@ namespace gjs {
 	void set_builtin_context(vm_context* ctx);
 	void init_context(vm_context* ctx);
 	
-	void* script_allocate(u32 size);
+	void* script_allocate(uinteger size);
 	void script_free(void* ptr);
+	void script_copymem(void* to, void* from, uinteger size);
 };

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <types.h>
+
+namespace gjs {
+	class vm_context;
+	void set_builtin_context(vm_context* ctx);
+	void init_context(vm_context* ctx);
+	
+	void* script_allocate(u32 size);
+	void script_free(void* ptr);
+};

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -4,6 +4,7 @@
 #include <compile.h>
 #include <asmjit/asmjit.h>
 #include <default_steps.h>
+#include <builtin.h>
 
 namespace gjs {
 	runtime_exception::runtime_exception(vm_context* ctx, const std::string& _text) : text(_text), raised_from_script(true), line(0), col(0) {
@@ -33,71 +34,7 @@ namespace gjs {
 		m_instructions += encode(vm_instruction::term);
 		m_map.append("[internal code]", "", 0, 0);
 
-		vm_type* tp = nullptr;
-		tp = m_types.add("i32", typeid(i32).name());
-		tp->is_primitive = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(i32);
-
-		tp = nullptr;
-		tp = m_types.add("u32", typeid(u32).name());
-		tp->is_primitive = true;
-		tp->is_unsigned = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(u32);
-
-		tp = nullptr;
-		tp = m_types.add("i16", typeid(i16).name());
-		tp->is_primitive = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(i16);
-
-		tp = nullptr;
-		tp = m_types.add("u16", typeid(u16).name());
-		tp->is_primitive = true;
-		tp->is_unsigned = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(u16);
-
-		tp = nullptr;
-		tp = m_types.add("i8", typeid(i8).name());
-		tp->is_primitive = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(i8);
-
-		tp = nullptr;
-		tp = m_types.add("u8", typeid(u8).name());
-		tp->is_primitive = true;
-		tp->is_unsigned = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(u8);
-
-		tp = m_types.add("f32", typeid(f32).name());
-		tp->is_primitive = true;
-		tp->is_floating_point = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(f32);
-
-		tp = m_types.add("f64", typeid(f64).name());
-		tp->is_primitive = true;
-		tp->is_floating_point = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(f64);
-
-		tp = m_types.add("bool", typeid(bool).name());
-		tp->is_primitive = true;
-		tp->is_builtin = true;
-		tp->size = sizeof(bool);
-
-		tp = m_types.add("string", "char");
-		tp->is_primitive = false;
-		tp->is_builtin = true;
-		tp->size = sizeof(char*);
-
-		tp = m_types.add("void", "void");
-		tp->is_primitive = true;
-		tp->is_builtin = true;
-		tp->size = 0;
+		init_context(this);
 
 		m_pipeline.add_ir_step(ir_remove_trailing_stack_loads);
 	}

--- a/src/default_steps.cpp
+++ b/src/default_steps.cpp
@@ -49,6 +49,7 @@ namespace gjs {
 	}
 
 	void ir_remove_trailing_stack_loads(vm_context* ctx, instruction_array& ir, source_map* map, u32 start_addr) {
+		return;
 		vmi min_load = vmi::ld8;
 		vmi max_load = vmi::ld64;
 		vector<u32> remove_addrs;

--- a/src/default_steps.cpp
+++ b/src/default_steps.cpp
@@ -48,6 +48,7 @@ namespace gjs {
 		}
 	}
 
+	// de-necessitated 
 	void ir_remove_trailing_stack_loads(vm_context* ctx, instruction_array& ir, source_map* map, u32 start_addr) {
 		return;
 		vmi min_load = vmi::ld8;

--- a/src/default_steps.cpp
+++ b/src/default_steps.cpp
@@ -14,7 +14,7 @@ namespace gjs {
 		map->map.erase(map->map.begin() + addr);
 
 		for (u32 a = start_addr;a < ir.size();a++) {
-			vmi i = decode_instruction(ir[a]);
+			vmi i = ir[a].instr();
 
 			switch (i) {
 				case vmi::beqz:
@@ -23,15 +23,15 @@ namespace gjs {
 				case vmi::bgtez:
 				case vmi::bltz:
 				case vmi::bltez: {
-					vmr reg = decode_operand_1(ir[a]);
-					uinteger fail_addr = decode_operand_2ui(ir[a]);
+					vmr reg = ir[a].op_1r();
+					u64 fail_addr = ir[a].imm_u();
 					if (fail_addr > addr) fail_addr--;
 					ir.set(a, encode(i).operand(reg).operand(fail_addr));
 					break;
 				}
 				case vmi::jmp:
 				case vmi::jal: {
-					u64 jmp_addr = decode_operand_1ui64(ir[a]);
+					u64 jmp_addr = ir[a].imm_u();
 					if (jmp_addr > addr && jmp_addr <= ir.size()) jmp_addr--;
 					ir.set(a, encode(i).operand(jmp_addr));
 					break;
@@ -66,19 +66,19 @@ namespace gjs {
 			if (f) cur_func = f;
 			if (!cur_func) continue;
 
-			vmi i = decode_instruction(ir[a]);
-			if (i >= min_load && i <= max_load && !reg_is_safe(decode_operand_1(ir[a]), { vmr::ra, cur_func->signature.return_loc })) {
+			vmi i = ir[a].instr();
+			if (i >= min_load && i <= max_load && !reg_is_safe(ir[a].op_1r(), { vmr::ra, cur_func->signature.return_loc })) {
 				remove_addrs.clear();
 				remove_addrs.push_back(a);
 				bool function_exits_after = true;
 				for (u32 b = a + 1;b < ir.size();b++) {
-					vmi ib = decode_instruction(ir[b]);
+					vmi ib = ir[b].instr();
 					if (ib >= min_load && ib <= max_load) {
-						if (!reg_is_safe(decode_operand_1(ir[a]), { vmr::ra, cur_func->signature.return_loc })) {
+						if (!reg_is_safe(ir[a].op_1r(), { vmr::ra, cur_func->signature.return_loc })) {
 							remove_addrs.push_back(b);
 						}
 					} else if (ib == vmi::jmpr) {
-						vmr to = decode_operand_1(ir[b]);
+						vmr to = ir[b].op_1r();
 						if (to != vmr::ra) function_exits_after = false;
 						break;
 					} else {

--- a/src/instruction_array.cpp
+++ b/src/instruction_array.cpp
@@ -15,7 +15,7 @@ namespace gjs {
 		m_instructions = nullptr;
 	}
 
-	void instruction_array::operator += (const instruction_encoder& i) {
+	void instruction_array::operator += (const instruction& i) {
 		if (!m_instructions) return;
 		m_instructions[m_count++] = i;
 		if (m_count == m_capacity) {
@@ -25,23 +25,13 @@ namespace gjs {
 		}
 	}
 
-	void instruction_array::operator += (instruction i) {
-		if (!m_instructions) return;
-		m_instructions[m_count++] = i;
-		if (m_count == m_capacity) {
-			m_capacity += RESIZE_AMOUNT;
-			m_instructions = (instruction*)m_allocator->reallocate(m_instructions, m_capacity * sizeof(instruction));
-			memset(m_instructions + m_count, 0, RESIZE_AMOUNT * sizeof(instruction));
-		}
-	}
-
-	void instruction_array::remove(u32 from, u32 to) {
+	void instruction_array::remove(u64 from, u64 to) {
 		if (to > m_count) {
 			m_count = from;
 			return;
 		}
-		for (u32 i = from;i < to;i++) {
-			u32 take = to + (i - from);
+		for (u64 i = from;i < to;i++) {
+			u64 take = to + (i - from);
 			if (take < m_count) m_instructions[i] = m_instructions[take];
 			else break;
 		}
@@ -49,8 +39,8 @@ namespace gjs {
 		else m_count = 0;
 	}
 
-	void instruction_array::remove(u32 index) {
-		for (u32 i = index;i < m_count - 1;i++) {
+	void instruction_array::remove(u64 index) {
+		for (u64 i = index;i < m_count - 1;i++) {
 			m_instructions[i] = m_instructions[i + 1];
 		}
 		if (m_count > 0) m_count--;

--- a/src/instruction_array.h
+++ b/src/instruction_array.h
@@ -10,20 +10,18 @@ namespace gjs {
 			instruction_array(vm_allocator* allocator);
 			~instruction_array();
 
-			void operator += (const instruction_encoder& i);
-			void operator += (instruction i);
+			void operator += (const instruction& i);
 
 			inline instruction operator[](u32 index) const { return m_instructions[index]; }
-			inline void set(u32 index, const instruction_encoder& i) { m_instructions[index] = i; }
-			inline void set(u32 index, instruction i) { m_instructions[index] = i; }
-			inline u32 size() const { return m_count; }
-			void remove(u32 from, u32 to);
-			void remove(u32 index);
+			inline void set(u64 index, const instruction& i) { m_instructions[index] = i; }
+			inline u64 size() const { return m_count; }
+			void remove(u64 from, u64 to);
+			void remove(u64 index);
 
 		protected:
 			vm_allocator* m_allocator;
 			instruction* m_instructions;
-			u32 m_count;
-			u32 m_capacity;
+			u64 m_count;
+			u64 m_capacity;
 	};
 };

--- a/src/instruction_encoder.cpp
+++ b/src/instruction_encoder.cpp
@@ -1,23 +1,12 @@
-#include <instruction_encoder.h>
 #include <instruction.h>
+#include <instruction_encoder.h>
 #include <register.h>
-#include <vm_state.h>
-#include <parse_utils.h>
+#include <context.h>
+#include <util.h>
 
 namespace gjs {
 	using vmi = vm_instruction;
 	using vmr = vm_register;
-
-	 #define debug(i) // print_i_bits(i)
-	 void print_i_bits (instruction i) {
-		system("cls");
-		for (int b = 63;b >= 0;b--) printf("%2.2d: %d\n", 64 - b, (u8)(i >> b) & 1);
-	 }
-	
-	instruction_encoder::instruction_encoder(vm_instruction i) {
-		m_result = instruction(i) << instruction_shift;
-		debug(m_result);
-	}
 
 	// term, null
 	#define check_instr_type_0(x)	\
@@ -44,7 +33,7 @@ namespace gjs {
 			|| x == vmi::pop		\
 		)
 
-	// b*, push, pop
+	// bits*, push, pop
 	#define check_instr_type_3(x)	\
 		(							\
 			   x == vmi::beqz		\
@@ -264,9 +253,18 @@ namespace gjs {
 		)
 
 	#define is_fpr(x) (x >= vmr::f0 && x <= vmr::f15)
+	#define decode_instr ((vmi)(m_code >> instr_shift))
+	#define check_flag(f) (((m_code | flag_mask) ^ flag_mask) & f)
+	#define set_flag(f) (m_code |= f)
 
-	instruction_encoder& instruction_encoder::operand(vm_register reg) {
-		vmi instr = decode_instruction(m_result);
+	instruction::instruction() : m_code(0), m_imm(0) { }
+
+	instruction::instruction(vm_instruction i) : m_code(0), m_imm(0) {
+		m_code |= u32(i) << instr_shift;
+	}
+
+	instruction& instruction::operand(vm_register reg) {
+		vmi instr = decode_instr;
 		if (check_instr_type_0(instr)) {
 			// instruction takes no operands
 			// exception
@@ -279,14 +277,14 @@ namespace gjs {
 			return *this;
 		}
 
-		if (m_result & (1 << 2)) {
+		if (check_flag(op_3_assigned)) {
 			// operand 3 already set, no instructions take a 4th operand
 			// exception
 			return *this;
 		}
 
 		// maybe set operand 3
-		if (m_result & (1 << 1)) {
+		if (check_flag(op_2_assigned)) {
 			// operand 2 already set
 			if (!third_operand_is_register(instr)) {
 				// instruction does not need third operand or third operand can not be a register
@@ -300,14 +298,13 @@ namespace gjs {
 				return *this;
 			}
 
-			m_result |= 1 << 2;
-			m_result |= instruction(reg) << operand_3r_shift;
-			debug(m_result);
+			set_flag(op_3_assigned);
+			m_code |= u32(reg) << op_3_shift;
 			return *this;
 		}
 		
 		// maybe set operand 2
-		if (m_result & 1) {
+		if (check_flag(op_1_assigned)) {
 			// operand 1 already set
 			if (!second_operand_is_register(instr)) {
 				// instruction does not need second operand or second operand can not be a register
@@ -321,9 +318,8 @@ namespace gjs {
 				return *this;
 			}
 
-			m_result |= 1 << 1;
-			m_result |= instruction(reg) << operand_2r_shift;
-			debug(m_result);
+			set_flag(op_2_assigned);
+			m_code |= u32(reg) << op_2_shift;
 			return *this;
 		}
 
@@ -340,27 +336,30 @@ namespace gjs {
 			return *this;
 		}
 
-		m_result |= 1;
-		m_result |= instruction(reg) << operand_1r_shift;
-		debug(m_result);
+		set_flag(op_1_assigned);
+		m_code |= u32(reg) << op_1_shift;
 		return *this;
 	}
 
-	instruction_encoder& instruction_encoder::operand(integer immediate) {
-		vmi instr = decode_instruction(m_result);
+	instruction& instruction::operand(i64 immediate) {
+		return operand(*(u64*)&immediate);
+	}
+
+	instruction& instruction::operand(u64 immediate) {
+		vmi instr = decode_instr;
 		if (check_instr_type_0(instr)) {
 			// instruction takes no operands
 			// exception
 			return *this;
 		}
 
-		if (m_result & (1 << 2)) {
+		if (check_flag(op_3_assigned)) {
 			// operand 3 already set
 			// exception
 			return *this;
 		}
 
-		if (m_result & (1 << 1)) {
+		if (check_flag(op_2_assigned)) {
 			// operand 2 already set
 			if (!third_operand_is_immediate(instr)) {
 				// instruction does not take third operand or third operand is not immediate
@@ -374,13 +373,12 @@ namespace gjs {
 				return *this;
 			}
 
-			m_result |= 1 << 2;
-			m_result |= instruction(immediate) << operand_3i_shift;
-			debug(m_result);
+			set_flag(op_3_assigned);
+			m_imm = immediate;
 			return *this;
 		}
 
-		if (m_result & 1) {
+		if (check_flag(op_1_assigned)) {
 			// operand 1 already set
 			if (!second_operand_is_immediate(instr)) {
 				// instruction does not take second operand or second operand is not immediate
@@ -388,9 +386,8 @@ namespace gjs {
 				return *this;
 			}
 
-			m_result |= 1 << 1;
-			m_result |= instruction(immediate) << operand_2i_shift;
-			debug(m_result);
+			set_flag(op_2_assigned);
+			m_imm = immediate;
 			return *this;
 		}
 
@@ -400,87 +397,26 @@ namespace gjs {
 			// exception
 			return *this;
 		}
-		m_result |= 1;
-		m_result |= instruction(immediate) << operand_1i_shift;
-		debug(m_result);
+		
+		set_flag(op_1_assigned);
 		return *this;
 	}
 
-	instruction_encoder& instruction_encoder::operand(uinteger immediate) {
-		vmi instr = decode_instruction(m_result);
+	instruction& instruction::operand(f64 immediate) {
+		vmi instr = decode_instr;
 		if (check_instr_type_0(instr)) {
 			// instruction takes no operands
 			// exception
 			return *this;
 		}
 
-		if (m_result & (1 << 2)) {
+		if (check_flag(op_3_assigned)) {
 			// operand 3 already set
 			// exception
 			return *this;
 		}
 
-		if (m_result & (1 << 1)) {
-			// operand 2 already set
-			if (!third_operand_is_immediate(instr)) {
-				// instruction does not take third operand or third operand is not immediate
-				// exception
-				return *this;
-			}
-
-			if (third_operand_must_be_fpi(instr)) {
-				// instruction requires that the third operand be floating point
-				// exception
-				return *this;
-			}
-
-			m_result |= 1 << 2;
-			m_result |= instruction(immediate) << operand_3i_shift;
-			debug(m_result);
-			return *this;
-		}
-
-		if (m_result & 1) {
-			// operand 1 already set
-			if (!second_operand_is_immediate(instr)) {
-				// instruction does not take second operand or second operand is not immediate
-				// exception
-				return *this;
-			}
-
-			m_result |= 1 << 1;
-			m_result |= instruction(immediate) << operand_2i_shift;
-			debug(m_result);
-			return *this;
-		}
-
-		// operand 1
-		if (!first_operand_is_immediate(instr)) {
-			// instruction does not take an operand or first operand is not immediate
-			// exception
-			return *this;
-		}
-		m_result |= 1;
-		m_result |= instruction(immediate) << operand_1i_shift;
-		debug(m_result);
-		return *this;
-	}
-
-	instruction_encoder& instruction_encoder::operand(decimal immediate) {
-		vmi instr = decode_instruction(m_result);
-		if (check_instr_type_0(instr)) {
-			// instruction takes no operands
-			// exception
-			return *this;
-		}
-
-		if (m_result & (1 << 2)) {
-			// operand 3 already set
-			// exception
-			return *this;
-		}
-
-		if (m_result & (1 << 1)) {
+		if (check_flag(op_2_assigned)) {
 			// operand 2 already set
 			if (!third_operand_is_immediate(instr)) {
 				// instruction does not take third operand or third operand is not immediate
@@ -494,13 +430,8 @@ namespace gjs {
 				return *this;
 			}
 
-			debug(m_result);
-			m_result |= 1 << 2;
-			debug(m_result);
-			m_result |= instruction(1) << operand_3_is_flt_shift;
-			debug(m_result);
-			m_result |= instruction(*(integer*)&immediate) << operand_3i_shift;
-			debug(m_result);
+			set_flag(op_3_is_float);
+			m_imm = *(u64*)&immediate;
 			return *this;
 		}
 
@@ -509,55 +440,11 @@ namespace gjs {
 		return *this;
 	}
 
-	instruction_encoder& instruction_encoder::operand(u64 immediate) {
-		vmi instr = decode_instruction(m_result);
-		if (check_instr_type_0(instr)) {
-			// instruction takes no operands
-			// exception
-			return *this;
-		}
+	std::string instruction::to_string(vm_context* ctx) const {
+		vm_state* state = ctx ? ctx->state() : nullptr;
 
-		if (!check_instr_type_1(instr)) {
-			// only type 1 instructions can take this kind of operand
-			// exception
-			return *this;
-		}
-
-		if (m_result & (1 << 2)) {
-			// operand 3 already set
-			// exception
-			return *this;
-		}
-
-		if (m_result & (1 << 1)) {
-			// operand 2 already set
-			// this type of operand can only be assigned to the first operand
-			// exception
-			return *this;
-		}
-
-		if (m_result & 1) {
-			// operand 1 already set
-			// this type of operand can only be assigned to the first operand
-			// exception
-			return *this;
-		}
-
-		// operand 1
-		if (!first_operand_is_immediate(instr)) {
-			// instruction does not take an operand or first operand is not immediate
-			// exception
-			return *this;
-		}
-
-		m_result |= instruction((immediate | operand_1_integer_mask) ^ operand_1_integer_mask) << operand_1i_shift;
-		debug(m_result);
-		return *this;
-	}
-
-	std::string instruction_to_string(instruction code, vm_state* state) {
 		std::string out;
-		vmi i = decode_instruction(code);
+		vmi i = instr();
 		if (i >= vmi::instruction_count) return "Invalid Instruction";
 
 		if (check_instr_type_0(i)) return instruction_str[(u8)i];
@@ -588,76 +475,76 @@ namespace gjs {
 		out += instruction_str[(u8)i];
 		while (out.length() < 8) out += ' ';
 		if (check_instr_type_1(i)) {
-			u64 o1 = decode_operand_1ui64(code);
+			u64 o1 = imm_u();
 			out += format("0x%llX", o1);
 		} else if (check_instr_type_2(i)) {
-			vmr o1 = decode_operand_1(code);
+			vmr o1 = op_1r();
 			if (o1 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o1);
 		} else if (check_instr_type_3(i)) {
-			vmr o1 = decode_operand_1(code);
+			vmr o1 = op_1r();
 			if (o1 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o1);
 			out += ", ";
 
-			integer o2 = decode_operand_2ui(code);
+			integer o2 = imm_u();
 			out += format("0x%llX", o2);
 		} else if (check_instr_type_5(i)) {
-			vmr o1 = decode_operand_1(code);
+			vmr o1 = op_1r();
 			if (o1 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o1);
 			out += ", ";
 
-			vmr o2 = decode_operand_2(code);
+			vmr o2 = op_2r();
 			if (o2 >= vmr::register_count) return "Invalid Instruction";
 
-			integer o3 = decode_operand_3i(code);
+			integer o3 = imm_i();
 			char offset[32] = { 0 };
 			_itoa_s<32>(o3, offset, 10);
 			out += offset;
 			out += '(' + reg_str(o2, o3, true) + ')';
 		} else if (check_instr_type_6(i)) {
-			vmr o1 = decode_operand_1(code);
+			vmr o1 = op_1r();
 			if (o1 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o1);
 			out += ", ";
 
-			vmr o2 = decode_operand_2(code);
+			vmr o2 = op_2r();
 			if (o2 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o2);
 			out += ", ";
 
-			if (decode_operator_3_is_float(code)) {
-				decimal o3 = decode_operand_3f(code);
+			if (imm_is_flt()) {
+				decimal o3 = imm_f();
 				char imm[32] = { 0 };
 				snprintf(imm, 32, "%f", o3);
 				out += imm;
 			} else {
-				integer o3 = decode_operand_3i(code);
+				integer o3 = imm_i();
 				char imm[32] = { 0 };
 				_itoa_s<32>(o3, imm, 10);
 				out += imm;
 			}
 
 		} else if (check_instr_type_7(i)) {
-			vmr o1 = decode_operand_1(code);
+			vmr o1 = op_1r();
 			if (o1 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o1);
 			out += ", ";
 
-			vmr o2 = decode_operand_2(code);
+			vmr o2 = op_2r();
 			if (o2 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o2);
 			out += ", ";
 
-			vmr o3 = decode_operand_3(code);
+			vmr o3 = op_3r();
 			if (o3 >= vmr::register_count) return "Invalid Instruction";
 
 			out += reg_str(o3);

--- a/src/instruction_encoder.cpp
+++ b/src/instruction_encoder.cpp
@@ -577,8 +577,8 @@ namespace gjs {
 
 				std::string reg_val = ""; // "<" + state->registers[(integer)r].to_string() + ">"
 
-				if (is_fpr(r)) reg_val = format("<%f>", decimal(state->registers[(integer)r]));
-				else reg_val = format("<%d>", integer(state->registers[(integer)r]));
+				if (is_fpr(r)) reg_val = format("<%f>", *(f32*)&state->registers[(integer)r]);
+				else reg_val = format("<%d>", *(i32*)&state->registers[(integer)r]);
 				return "$" + std::string(register_str[(integer)r]) + reg_val;
 			}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,8 +26,8 @@ class foo {
 };
 
 struct vec3 { f32 x, y, z; };
-void testvec(void** vec) {
-	vec3& v = **(vec3**)vec;
+void testvec(void* vec) {
+	vec3& v = *(vec3*)vec;
 	printf("%f, %f, %f\n", v.x, v.y, v.z);
 }
 
@@ -146,6 +146,7 @@ int main(int arg_count, const char** args) {
 	print_code(ctx);
 
 	printf("-------------result-------------\n");
+	ctx.function("it")->call<void*>(nullptr);
 
 	int x = 5;
 	foo test(&x);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,9 @@ class foo {
 		i32 y;
 		i32 z;
 		f32 w;
+		static f64 s;
 };
+f64 foo::s = 5.5;
 
 struct vec3 { f32 x, y, z; };
 void testvec(void* vec) {
@@ -103,7 +105,7 @@ void print_code(vm_context& ctx) {
 			}
 			printf("]\n");
 		}
-		printf("0x%2.2X: %-32s", i, instruction_to_string((*ctx.code())[i]).c_str());
+		printf("0x%2.2X: %-32s", i, (*ctx.code())[i].to_string().c_str());
 
 		auto src = ctx.map()->get(i);
 		if (src.lineText != last_line) {
@@ -136,7 +138,7 @@ int main(int arg_count, const char** args) {
 
 	try {
 		auto f = ctx.bind<foo>("foo");
-		f.constructor<integer*>();
+		f.constructor<i32*>();
 		f.method("t", &foo::t);
 		f.method("operator i32", &foo::operator i32);
 		f.method("static_func", &foo::static_func);
@@ -144,6 +146,7 @@ int main(int arg_count, const char** args) {
 		f.prop("y", &foo::y, bind::property_flags::pf_none);
 		f.prop("z", &foo::z, bind::property_flags::pf_none);
 		f.prop("w", &foo::w, bind::property_flags::pf_none);
+		f.prop("s", &foo::s, bind::property_flags::pf_none);
 		f.finalize();
 
 		ctx.bind(print_foo, "print_foo");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,11 +6,15 @@ using namespace gjs;
 
 class foo {
 	public:
-		foo(i32* _x) { x = _x; w = 3.0f; }
-		~foo() { }
+		foo(i32* _x) : x(_x), y(0), z(0), w(0.0f) {
+			printf("Construct foo\n");
+		}
+		~foo() {
+			printf("Destruct foo\n");
+		}
 
-		i32 t(i32 a) {
-			return printf("%d, %d\n", y, a);
+		i32 t(i32 a, i32* b) {
+			return printf("%d, %d, %d\n", y, a, *b);
 		}
 
 		operator i32() { return y; }
@@ -20,6 +24,12 @@ class foo {
 		i32 z;
 		f32 w;
 };
+
+struct vec3 { f32 x, y, z; };
+void testvec(void** vec) {
+	vec3& v = **(vec3**)vec;
+	printf("%f, %f, %f\n", v.x, v.y, v.z);
+}
 
 void print_foo(const foo& f) {
 	printf("foo: %d, %d, %d, %f\n", *f.x, f.y, f.z, f.w);
@@ -122,6 +132,7 @@ int main(int arg_count, const char** args) {
 		f.finalize();
 
 		ctx.bind(print_foo, "print_foo");
+		ctx.bind(testvec, "testvec");
 	} catch (bind_exception& e) {
 		printf("%s\n", e.text.c_str());
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,7 +85,7 @@ void print_code(vm_context& ctx) {
 			}
 			printf(")");
 
-			if (f->signature.return_type->size == 0) printf(" -> null");
+			if (f->signature.return_type->name == "void") printf(" -> null");
 			else printf(" -> $%s", register_str[u8(f->signature.return_loc)]);
 			printf("]\n");
 		}
@@ -146,15 +146,9 @@ int main(int arg_count, const char** args) {
 	print_code(ctx);
 
 	printf("-------------result-------------\n");
-	ctx.function("it")->call<void*>(nullptr);
-
-	int x = 5;
-	foo test(&x);
-	test.y = 10;
-	test.z = 4;
-	integer result = 0;
-	vm_function* func = ctx.function("main");
 	ctx.log_instructions(true);
-	if (func) func->call(&result, &test);
+	ctx.function("it");
+	vm_function* func = ctx.function("it");
+	if (func) func->call<void*>(nullptr);
 	return 0;
 }

--- a/src/parse.h
+++ b/src/parse.h
@@ -23,6 +23,7 @@ namespace gjs {
 			import_statement,
 			export_statement,
 			return_statement,
+			delete_statement,
 			object,
 			call,
 			expression,
@@ -81,7 +82,8 @@ namespace gjs {
 			negate,
 			addr,
 			at,
-			member
+			member,
+			newObj
 		};
 
 		struct source_location {

--- a/src/parse.h
+++ b/src/parse.h
@@ -83,7 +83,8 @@ namespace gjs {
 			addr,
 			at,
 			member,
-			newObj
+			newObj,
+			stackObj
 		};
 
 		struct source_location {

--- a/src/parse_utils.h
+++ b/src/parse_utils.h
@@ -23,7 +23,9 @@ namespace gjs {
 			};
 
 			void specify_keyword(const std::string& keyword);
+			void specify_operator(const std::string& op);
 			bool is_keyword(const std::string& thing);
+			bool is_operator(const std::string& op);
 			bool is_number(const std::string& thing);
 			bool is_identifier(const std::string& thing);
 			inline std::string line_str() const { return lines[m_line]; }
@@ -43,6 +45,7 @@ namespace gjs {
 			token any_token();
 			token semicolon(bool expected = true);
 			token keyword(bool expected = true, const std::string& kw = "");
+			token operat0r(bool expected = true, const std::string& op = "");
 			token identifier(bool expected = true, const std::string& identifier = "");
 			token character(char c, bool expected = true);
 			token expression(bool expected = true);
@@ -54,6 +57,7 @@ namespace gjs {
 
 		protected:
 			std::vector<std::string> m_keywords;
+			std::vector<std::string> m_operators;
 			std::string m_input;
 			struct stored_state {
 				u32 idx;

--- a/src/types.h
+++ b/src/types.h
@@ -15,10 +15,8 @@ namespace gjs {
 	typedef float		f32;
 	typedef double		f64;
 
-	typedef uint64_t	instruction;
-	typedef uint32_t	address;
-	typedef float		decimal;
-	typedef int32_t		integer;
-	typedef uint32_t	uinteger;
-	typedef int16_t		memory_offset;
+	typedef u64			address;
+	typedef f64			decimal;
+	typedef i64			integer;
+	typedef u64			uinteger;
 };

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -43,6 +43,8 @@ namespace gjs {
 	#define _O3ui decode_operand_3ui(i)
 	#define _O3f decode_operand_3f(i)
 
+	#define STACK_PADDING_SIZE 8
+
 	vm::vm(vm_context* ctx, vm_allocator* allocator, u32 stack_size, u32 mem_size) : m_ctx(ctx), alloc(allocator), state(mem_size), m_stack_size(stack_size) {
 	}
 
@@ -54,8 +56,11 @@ namespace gjs {
 		
 		GR64(vmr::ip) = (integer)entry;
 		GR64(vmr::ra) = 0;
-		GR64(vmr::sp) = 0;
+		GR64(vmr::sp) = (u64)state.memory[0];
 		GR64(vmr::zero) = 0;
+
+		u64 stack_padding_start = ((u64)state.memory[0]) + m_stack_size;
+		u64 stack_padding_end = stack_padding_start + STACK_PADDING_SIZE;
 
 		instruction i;
 		integer* ip = &GRi(vmr::ip);
@@ -80,92 +85,80 @@ namespace gjs {
                 // load 1 byte from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld8: {
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u8* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u8*)offset;
-					} else ptr = (u8*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u8* ptr = (u8*)offset;
 					GR64(_O1) = *(u8*)ptr;
                     break;
                 }
                 // load 2 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld16: {
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u16* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u16*)offset;
-					} else ptr = (u16*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u16* ptr = (u16*)offset;
 					GR64(_O1) = *(u16*)ptr;
                     break;
                 }
                 // load 4 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld32: {
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u32* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u32*)offset;
-					} else ptr = (u32*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u32* ptr = (u32*)offset;
 					GR64(_O1) = *(u32*)ptr;
                     break;
                 }
                 // load 8 bytes from memory into register			ld8		(dest)	(src)	0		dest = *(src + 0)
                 case vmi::ld64: {
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u64* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u64*)offset;
-					} else ptr = (u64*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u64* ptr = (u64*)offset;
 					GR64(_O1) = *(u64*)ptr;
                     break;
                 }
                 // store 1 byte in memory from register				store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st8: {
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u8* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u8*)offset;
-					} else ptr = (u8*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u8* ptr = (u8*)offset;
 					*ptr = GR8(_O1);
                     break;
                 }
                 // store 2 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st16: {
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u16* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u16*)offset;
-					} else ptr = (u16*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u16* ptr = (u16*)offset;
 					*ptr = GR16(_O1);
                     break;
                 }
                 // store 4 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st32: {
-					vmr reg = _O2;
-					u64 o1 = GR64(integer(reg));
-					u64 o2 = _O3i;
-					u64 o3 = _O3ui;
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u32* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u32*)offset;
-					} else ptr = (u32*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u32* ptr = (u32*)offset;
 					*ptr = GR32(_O1);
                     break;
                 }
                 // store 8 bytes in memory from register			store	(src)	(dest)	10		dest = *(src + 10)
                 case vmi::st64: {
 					u64 offset = GR64(integer(_O2)) + _O3i;
-					u64* ptr = nullptr;
-					if (offset < 0 || offset >= state.memory.size()) {
-						// maybe do some kind of checking
-						ptr = (u64*)offset;
-					} else ptr = (u64*)state.memory[offset];
+					if (offset >= stack_padding_start && offset <= stack_padding_end) {
+						throw runtime_exception(m_ctx, "Stack overflow detected");
+					}
+					u64* ptr = (u64*)offset;
 					*ptr = GR64(_O1);
                     break;
                 }
@@ -532,7 +525,7 @@ namespace gjs {
 					GR64(_O1) = GRd(_O2) == _O3f;
 					break;
 				}
-				 // check if register not equal register				fncmp	(dest)	(a)		(b)		dest = a != b
+				// check if register not equal register				fncmp	(dest)	(a)		(b)		dest = a != b
 				case vmi::fncmp: {
 					GR64(_O1) = GRd(_O2) != GRd(_O3);
 					break;
@@ -634,7 +627,7 @@ namespace gjs {
 					args.push_back(reinterpret_cast<void*>(*reg));
 				}
 			} else {
-				// *reg is a pointer to some value
+				// *reg is a pointer to some structure
 				if (is_ptr) {
 					args.push_back(reinterpret_cast<void*>(*reg));
 				} else {
@@ -647,7 +640,16 @@ namespace gjs {
 		}
 
 		void* ret_addr = nullptr;
-		if (f->signature.return_loc != vmr::register_count) ret_addr = &(m_ctx->state()->registers[(u8)f->signature.return_loc]);
+		if (f->signature.return_type->size > 0) {
+			ret_addr = &(m_ctx->state()->registers[(u8)f->signature.return_loc]);
+			if (f->signature.returns_on_stack) {
+				u64 return_value_end = u64(ret_addr) + f->signature.return_type->size;
+				u64 stack_end = (u64)state.memory[0] + m_stack_size;
+				if (return_value_end >= stack_end) {
+					throw runtime_exception(m_ctx, "Stack overflow detected");
+				}
+			}
+		}
 
 		f->access.wrapped->call(ret_addr, args.data());
 	}


### PR DESCRIPTION
- Implemented compiler logic for instantiating objects with dynamic allocation (constructed with `new`)
- Implemented compiler logic for instantiating objects on the stack (constructed without `new`)
- Stack objects are automatically deallocated at the end of their scope or once the expression they're used in terminates (if they aren't assigned to a variable initially)
- Added `u64`, `i64` data types to scripts
- Floating point immediate values are now of type `f64`
- Integer immediate values are now of type `i64`
- Added `memcopy` function for scripts (uses `memmove` rather than `memcpy`, in case there is overlap between `dest` and `src`)
- Compiler's `func::scope` now stores variables in an array instead of a map
- Moved builtin type binding to `builtin.h/.cpp`
- Added support for static class methods, properties
- Separated operators from keywords in `tokenizer`
- `$sp` now points to the actual memory address of the stack, rather than the index of it in `vm_memory`
- Function calls from scripts will no longer automatically restore all `func::var`s from the stack, They are restored upon their next use (to avoid unnecessary load instructions)
- Probably more I'm forgetting