### PR TITLE
Differentiate between f32 and f64

### DIFF
--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -1,4 +1,4 @@
 
 void it() {
-    foo.s = 1.5;
+    foo.s += 1.5f;
 }

--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -20,49 +20,6 @@ namespace gjs {
 	using op = ast_node::operation_type;
 	using vmr = vm_register;
 	using vmi = vm_instruction;
-	static const char* op_symbol[] = {
-		"invalid",
-		"+",
-		"-",
-		"*",
-		"/",
-		"%",
-		"<<",
-		">>",
-		"&&",
-		"||",
-		"&",
-		"|",
-		"^",
-		"+=",
-		"-=",
-		"*=",
-		"/=",
-		"%=",
-		"<<=",
-		">>=",
-		"&&=",
-		"||=",
-		"&=",
-		"|=",
-		"^=",
-		"++",
-		"--",
-		"++",
-		"--",
-		"<",
-		">",
-		"<=",
-		">=",
-		"!=",
-		"==",
-		"=",
-		"!",
-		"- (negate)",
-		"& (address)",
-		"* (dereference)",
-		"."
-	};
 
 	#define is_fp(r) (r >= vmr::f0 && r <= vmr::f15)
 	#define is_arg(r) (r >= vmr::a0 && r <= vmr::a7)

--- a/src/compiler/function.h
+++ b/src/compiler/function.h
@@ -83,7 +83,8 @@ namespace gjs {
 		var* allocate(compile_context& ctx, const std::string& name, data_type* type, bool is_arg = false);
 		var* allocate_stack_var(compile_context& ctx, data_type* type, ast_node* because);
 		var* imm(compile_context& ctx, integer i);
-		var* imm(compile_context& ctx, decimal d);
+		var* imm(compile_context& ctx, f32 f);
+		var* imm(compile_context& ctx, f64 d);
 		var* imm(compile_context& ctx, char* s);
 		var* zero(compile_context& ctx, data_type* type);
 		void free(var* v);

--- a/src/compiler/variable.cpp
+++ b/src/compiler/variable.cpp
@@ -172,18 +172,25 @@ namespace gjs {
 					because
 				);
 			} else {
-				ctx->add(
-					encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.d),
-					because
-				);
+				if (type->size == sizeof(f64)) {
+					ctx->add(
+						encode(vmi::daddi).operand(reg).operand(vmr::zero).operand(imm.f_64),
+						because
+					);
+				} else {
+					ctx->add(
+						encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.f_32),
+						because
+					);
+				}
 			}
 		} else {
 			vmi load;
 			switch (type->size) {
-			case 1: { load = vmi::ld8; break; }
-			case 2: { load = vmi::ld16; break; }
-			case 4: { load = vmi::ld32; break; }
-			case 8: { load = vmi::ld64; break; }
+				case 1: { load = vmi::ld8; break; }
+				case 2: { load = vmi::ld16; break; }
+				case 4: { load = vmi::ld32; break; }
+				case 8: { load = vmi::ld64; break; }
 			}
 			ctx->add(
 				encode(load).operand(reg).operand(vmr::sp).operand(loc.stack_addr + stack_offset),
@@ -243,10 +250,17 @@ namespace gjs {
 					because
 				);
 			} else {
-				ctx->add(
-					encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.d),
-					because
-				);
+				if (type->size == sizeof(f64)) {
+					ctx->add(
+						encode(vmi::daddi).operand(reg).operand(vmr::zero).operand(imm.f_64),
+						because
+					);
+				} else {
+					ctx->add(
+						encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.f_32),
+						because
+					);
+				}
 			}
 		} else {
 			vmi load;
@@ -276,29 +290,64 @@ namespace gjs {
 	void var::store_in(vmr reg, ast_node* because, integer stack_offset) {
 		if (is_reg) {
 			if (loc.reg == reg) return;
-			ctx->add(
-				encode(vmi::add).operand(reg).operand(loc.reg).operand(vmr::zero),
-				because
-			);
+			if (is_fp(reg) == is_fp(loc.reg)) {
+				if (is_fp(reg)) {
+					ctx->add(
+						encode(vmi::fadd).operand(reg).operand(loc.reg).operand(vmr::zero),
+						because
+					);
+				} else {
+					ctx->add(
+						encode(vmi::add).operand(reg).operand(loc.reg).operand(vmr::zero),
+						because
+					);
+				}
+			} else {
+				if (is_fp(loc.reg)) {
+					ctx->add(
+						encode(vmi::mffp).operand(loc.reg).operand(reg),
+						because
+					);
+				} else {
+					ctx->add(
+						encode(vmi::mtfp).operand(loc.reg).operand(reg),
+						because
+					);
+				}
+			}
 		} else if (is_imm) {
 			if (!type->is_floating_point) {
-				ctx->add(
-					encode(vmi::addi).operand(reg).operand(vmr::zero).operand(imm.i),
-					because
-				);
+				if (type->is_unsigned) {
+					ctx->add(
+						encode(vmi::addui).operand(reg).operand(vmr::zero).operand(imm.i),
+						because
+					);
+				} else {
+					ctx->add(
+						encode(vmi::addi).operand(reg).operand(vmr::zero).operand(imm.i),
+						because
+					);
+				}
 			} else {
-				ctx->add(
-					encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.d),
-					because
-				);
+				if (type->size == sizeof(f64)) {
+					ctx->add(
+						encode(vmi::daddi).operand(reg).operand(vmr::zero).operand(imm.f_64),
+						because
+					);
+				} else {
+					ctx->add(
+						encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.f_32),
+						because
+					);
+				}
 			}
 		} else {
 			vmi load;
 			switch (type->size) {
-			case 1: { load = vmi::ld8; break; }
-			case 2: { load = vmi::ld16; break; }
-			case 4: { load = vmi::ld32; break; }
-			case 8: { load = vmi::ld64; break; }
+				case 1: { load = vmi::ld8; break; }
+				case 2: { load = vmi::ld16; break; }
+				case 4: { load = vmi::ld32; break; }
+				case 8: { load = vmi::ld64; break; }
 			}
 			ctx->add(
 				encode(load).operand(reg).operand(vmr::sp).operand(loc.stack_addr + stack_offset),
@@ -320,18 +369,25 @@ namespace gjs {
 					because
 				);
 			} else {
-				ctx->add(
-					encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.d),
-					because
-				);
+				if (type->size == sizeof(f64)) {
+					ctx->add(
+						encode(vmi::daddi).operand(reg).operand(vmr::zero).operand(imm.f_64),
+						because
+					);
+				} else {
+					ctx->add(
+						encode(vmi::faddi).operand(reg).operand(vmr::zero).operand(imm.f_32),
+						because
+					);
+				}
 			}
 		} else {
 			vmi load;
 			switch (type->size) {
-			case 1: { load = vmi::ld8; break; }
-			case 2: { load = vmi::ld16; break; }
-			case 4: { load = vmi::ld32; break; }
-			case 8: { load = vmi::ld64; break; }
+				case 1: { load = vmi::ld8; break; }
+				case 2: { load = vmi::ld16; break; }
+				case 4: { load = vmi::ld32; break; }
+				case 8: { load = vmi::ld64; break; }
 			}
 			ctx->add(
 				encode(vmi::add).operand(vmr::v0).operand(vmr::sp).operand(stack_offset),
@@ -361,6 +417,7 @@ namespace gjs {
 			return call(ctx, cast_func, because, { from });
 		}
 
+		// todo: once overloading is supported, look for constructor that accepts from->type as the only parameter
 		if (!to->built_in) {
 			ctx.log->err(format("Cannot convert from '%s' to '%s'", from->type->name.c_str(), to->name.c_str()), because);
 			return from;
@@ -375,42 +432,83 @@ namespace gjs {
 			return from;
 		}
 
+		var* out = ctx.cur_func->allocate(ctx, to);
+		from->store_in(out->to_reg(because), because);
+
+		// signed -> signed or unsigned -> unsigned can be handled implicitly
+		if (from->type->is_unsigned == to->is_unsigned && !from->type->is_floating_point && !to->is_floating_point) return out;
+
+		vmi instr;
+
 		// only types remaining are integral
-		// todo: conversion between f32/f64
-		if (!from->type->is_floating_point) {
-			if (from->is_imm) return ctx.cur_func->imm(ctx, (decimal)from->imm.i);
-			var* tmp = ctx.cur_func->allocate(ctx, to);
-			ctx.add(
-				encode(vmi::mtfp).operand(from->to_reg(because)).operand(tmp->to_reg(because)),
-				because
-			);
-			ctx.add(
-				encode(vmi::ctf).operand(tmp->to_reg(because)),
-				because
-			);
-			return tmp;
+		if (from->type->is_floating_point) {
+			if (from->type->size == sizeof(f64)) {
+				// convert from f64
+				if (to->is_floating_point) {
+					// to f32
+					instr = vmi::cvt_df;
+				} else {
+					if (to->is_unsigned) {
+						// to u64, u32, u16, u8
+						instr = vmi::cvt_du;
+					} else {
+						// to i64, i32, i16, i8
+						instr = vmi::cvt_di;
+					}
+				}
+			} else {
+				// convert from f32
+				if (to->is_floating_point) {
+					// to f64
+					instr = vmi::cvt_fd;
+				} else {
+					if (to->is_unsigned) {
+						// to u64, u32, u16, u8
+						instr = vmi::cvt_fu;
+					} else {
+						// to i64, i32, i16, i8
+						instr = vmi::cvt_fi;
+					}
+				}
+			}
 		} else {
-			if (from->is_imm) return ctx.cur_func->imm(ctx, (integer)from->imm.d);
-			var* tmp = ctx.cur_func->allocate(ctx, to);
-			vmr treg = ctx.cur_func->registers.allocate_fp();
-			ctx.add(
-				encode(vmi::fadd).operand(treg).operand(from->to_reg(because)).operand(vmr::zero),
-				because
-			);
-			ctx.add(
-				encode(vmi::cti).operand(treg),
-				because
-			);
-			ctx.add(
-				encode(vmi::mffp).operand(treg).operand(tmp->to_reg(because)),
-				because
-			);
-			ctx.cur_func->registers.free(treg);
-			return tmp;
+			if (from->type->is_unsigned) {
+				// convert from u64, u32, u16, u8
+				if (to->is_floating_point) {
+					if (to->size == sizeof(f64)) {
+						// to f64
+						instr = vmi::cvt_ud;
+					} else {
+						// to f32
+						instr = vmi::cvt_uf;
+					}
+				} else {
+					// to i64, i32, i16, i8
+					instr = vmi::cvt_ui;
+				}
+			} else {
+				// convert from i64, i32, i16, i8
+				if (to->is_floating_point) {
+					if (to->size == sizeof(f64)) {
+						// to f64
+						instr = vmi::cvt_id;
+					} else {
+						// to f32
+						instr = vmi::cvt_if;
+					}
+				} else {
+					// to u64, u32, u16, u8
+					instr = vmi::cvt_iu;
+				}
+			}
 		}
 
-		ctx.log->err(format("No conversion from '%s' to '%s' found", from->type->name.c_str(), to->name.c_str()), because);
-		return from;
+		ctx.add(
+			encode(instr).operand(out->to_reg(because)),
+			because
+		);
+
+		return out;
 	}
 
 	var* cast(compile_context& ctx, var* from, var* to, ast_node* because) {

--- a/src/compiler/variable.h
+++ b/src/compiler/variable.h
@@ -34,7 +34,8 @@ namespace gjs {
 
 		union {
 			integer i;
-			decimal d;
+			f32 f_32;
+			f64 f_64;
 		} imm;
 
 		void move_stack_reference(var* to);

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -44,8 +44,18 @@ namespace gjs {
 		"divuir",
 
 		// integer / floating point conversion
-		"ctf",
-		"cti",
+		"cvt.i.f",
+		"cvt.i.d",
+		"cvt.i.u",
+		"cvt.u.f",
+		"cvt.u.d",
+		"cvt.u.i",
+		"cvt.f.i",
+		"cvt.f.u",
+		"cvt.f.d",
+		"cvt.d.i",
+		"cvt.d.u",
+		"cvt.d.f",
 
 		// floating point arithmetic
 		"fadd",
@@ -58,6 +68,16 @@ namespace gjs {
 		"fdiv",
 		"fdivi",
 		"fdivir",
+		"dadd",
+		"daddi",
+		"dsub",
+		"dsubi",
+		"dsubir",
+		"dmul",
+		"dmuli",
+		"ddiv",
+		"ddivi",
+		"ddivir",
 
 		// comparison
 		"lt",
@@ -86,6 +106,18 @@ namespace gjs {
 		"fcmpi",
 		"fncmp",
 		"fncmpi",
+		"dlt",
+		"dlti",
+		"dlte",
+		"dltei",
+		"dgt",
+		"dgti",
+		"dgte",
+		"dgtei",
+		"dcmp",
+		"dcmpi",
+		"dncmp",
+		"dncmpi",
 
 		// boolean
 		"and",

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -54,10 +54,21 @@ namespace gjs {
 		divuir			,	// divide immediate value by register				divuir	(dest)	(a)		1.0		dest = 1 / a
 
 		// integer / floating point conversion
-		ctf				,	// convert value to float							ctf		(a)						a = float(a)		(a must be fp)
-		cti				,	// convert float to integer							cti 	(a)						a = integer(a)		(a must be fp)
+		cvt_if			,	// convert integer to f32							cvt_if	(a)						a = f32(a)
+		cvt_id			,	// convert integer to f64							cvt_id	(a)						a = f64(a)
+		cvt_iu			,	// convert integer to uinteger						cvt_iu	(a)						a = uinteger_tp(a)
+		cvt_uf			,	// convert uinteger to f32							cvt_if	(a)						a = f32(a)
+		cvt_ud			,	// convert uinteger to f64							cvt_id	(a)						a = f64(a)
+		cvt_ui			,	// convert uinteger to integer						cvt_ui	(a)						a = integer_tp(a)
+		cvt_fi			,	// convert f32 to integer							cvt_fi 	(a)						a = integer_tp(a)
+		cvt_fu			,	// convert f32 to uinteger							cvt_fi 	(a)						a = uinteger_tp(a)
+		cvt_fd			,	// convert f32 to f64								cvt_fd 	(a)						a = f64(a)
+		cvt_di			,	// convert f64 to integer							cvt_di 	(a)						a = integer_tp(a)
+		cvt_du			,	// convert f64 to uinteger							cvt_di 	(a)						a = uinteger_tp(a)
+		cvt_df			,	// convert f64 to f32								cvt_df 	(a)						a = f32(a)
 
 		// floating point arithmetic (only accepts $fxx registers and floating point immediates)
+		// f32
 		fadd			,	// add two registers								fadd	(dest)	(a)		(b)		dest = a + b
 		faddi			,	// add register and immediate value					faddi	(dest)	(a)		1.0		dest = a + 1.0
 		fsub			,	// subtract register from another					fsub	(dest)	(a)		(b)		dest = a - b
@@ -68,6 +79,17 @@ namespace gjs {
 		fdiv			,	// divide register by another						fdiv	(dest)	(a)		(b)		dest = a / b
 		fdivi			,	// divide register by immediate value				fdivi	(dest)	(a)		1.0		dest = a / 1.0
 		fdivir			,	// divide immediate value by register				fdivir	(dest)	(a)		1.0		dest = 1.0 / a
+		// f64
+		dadd			,	// add two registers								fadd	(dest)	(a)		(b)		dest = a + b
+		daddi			,	// add register and immediate value					faddi	(dest)	(a)		1.0		dest = a + 1.0
+		dsub			,	// subtract register from another					fsub	(dest)	(a)		(b)		dest = a - b
+		dsubi			,	// subtract immediate value from register			fsubi	(dest)	(a)		1.0		dest = a - 1.0
+		dsubir			,	// subtract register from immediate value			fsubir	(dest)	(a)		1.0		dest = 1.0 - a
+		dmul			,	// multiply two registers							fmul	(dest)	(a)		(b)		dest = a * b
+		dmuli			,	// multiply register and immediate value			fmuli	(dest)	(a)		1.0		dest = a * 1.0
+		ddiv			,	// divide register by another						fdiv	(dest)	(a)		(b)		dest = a / b
+		ddivi			,	// divide register by immediate value				fdivi	(dest)	(a)		1.0		dest = a / 1.0
+		ddivir			,	// divide immediate value by register				fdivir	(dest)	(a)		1.0		dest = 1.0 / a
 
 		// comparison (need unsigned counterparts still)
 		lt				,	// check if register less than register				lt		(dest)	(a)		(b)		dest = a < b
@@ -84,6 +106,7 @@ namespace gjs {
 		ncmpi			,	// check if register not equal immediate			ncmpi	(dest)	(a)		1		dest = a != 1
 
 		// floating point comparison
+		// f32
 		flt				,	// check if register less than register				flt		(dest)	(a)		(b)		dest = a < b
 		flti			,	// check if register less than immediate			flti	(dest)	(a)		1.0		dest = a < 1.0
 		flte			,	// check if register less than or equal register	flte	(dest)	(a)		(b)		dest = a <= b
@@ -96,6 +119,19 @@ namespace gjs {
 		fcmpi			,	// check if register equal immediate				fcmpi	(dest)	(a)		1.0		dest = a == 1.0
 		fncmp			,	// check if register not equal register				fncmp	(dest)	(a)		(b)		dest = a != b
 		fncmpi			,	// check if register not equal immediate			fncmpi	(dest)	(a)		1.0		dest = a != 1.0
+		// f64
+		dlt				,	// check if register less than register				flt		(dest)	(a)		(b)		dest = a < b
+		dlti			,	// check if register less than immediate			flti	(dest)	(a)		1.0		dest = a < 1.0
+		dlte			,	// check if register less than or equal register	flte	(dest)	(a)		(b)		dest = a <= b
+		dltei			,	// check if register less than or equal immediate	fltei	(dest)	(a)		1.0		dest = a <= 1.0
+		dgt				,	// check if register greater than register			fgt		(dest)	(a)		(b)		dest = a > b
+		dgti			,	// check if register greater than immediate			fgti	(dest)	(a)		1.0		dest = a > 1.0
+		dgte			,	// check if register greater than or equal register	fgte	(dest)	(a)		(b)		dest = a >= b
+		dgtei			,	// check if register greater than or equal imm.		fgtei	(dest)	(a)		1.0		dest = a >= 1.0
+		dcmp			,	// check if register equal register					fcmp	(dest)	(a)		(b)		dest = a == b
+		dcmpi			,	// check if register equal immediate				fcmpi	(dest)	(a)		1.0		dest = a == 1.0
+		dncmp			,	// check if register not equal register				fncmp	(dest)	(a)		(b)		dest = a != b
+		dncmpi			,	// check if register not equal immediate			fncmpi	(dest)	(a)		1.0		dest = a != 1.0
 
 		// boolean
 		and				,	// logical and										and		(dest)	(a)		(b)		dest = a && b

--- a/src/instruction_encoder.cpp
+++ b/src/instruction_encoder.cpp
@@ -22,13 +22,21 @@ namespace gjs {
 			|| x == vmi::jmp		\
 		)
 
-	// jalr, jmpr, push, pop, ctf, cti
+	// jalr, jmpr, push, pop, cvt_*
 	#define check_instr_type_2(x)	\
 		(							\
 			   x == vmi::jalr		\
 			|| x == vmi::jmpr		\
-			|| x == vmi::ctf		\
-			|| x == vmi::cti		\
+			|| x == vmi::cvt_if		\
+			|| x == vmi::cvt_id		\
+			|| x == vmi::cvt_uf		\
+			|| x == vmi::cvt_ud		\
+			|| x == vmi::cvt_fi		\
+			|| x == vmi::cvt_fu		\
+			|| x == vmi::cvt_fd		\
+			|| x == vmi::cvt_di		\
+			|| x == vmi::cvt_du		\
+			|| x == vmi::cvt_df		\
 			|| x == vmi::push		\
 			|| x == vmi::pop		\
 		)
@@ -80,12 +88,36 @@ namespace gjs {
 			|| x == vmi::mului		\
 			|| x == vmi::divui		\
 			|| x == vmi::divuir		\
+			|| x == vmi::lti		\
+			|| x == vmi::ltei		\
+			|| x == vmi::gti		\
+			|| x == vmi::gtei		\
+			|| x == vmi::cmpi		\
+			|| x == vmi::ncmpi		\
 			|| x == vmi::faddi		\
 			|| x == vmi::fsubi		\
 			|| x == vmi::fsubir		\
 			|| x == vmi::fmuli		\
 			|| x == vmi::fdivi		\
 			|| x == vmi::fdivir		\
+			|| x == vmi::flti		\
+			|| x == vmi::fltei		\
+			|| x == vmi::fgti		\
+			|| x == vmi::fgtei		\
+			|| x == vmi::fcmpi		\
+			|| x == vmi::fncmpi		\
+			|| x == vmi::daddi		\
+			|| x == vmi::dsubi		\
+			|| x == vmi::dsubir		\
+			|| x == vmi::dmuli		\
+			|| x == vmi::ddivi		\
+			|| x == vmi::ddivir		\
+			|| x == vmi::dlti		\
+			|| x == vmi::dltei		\
+			|| x == vmi::dgti		\
+			|| x == vmi::dgtei		\
+			|| x == vmi::dcmpi		\
+			|| x == vmi::dncmpi		\
 			|| x == vmi::bandi		\
 			|| x == vmi::bori		\
 			|| x == vmi::xori		\
@@ -95,18 +127,6 @@ namespace gjs {
 			|| x == vmi::srir		\
 			|| x == vmi::andi		\
 			|| x == vmi::ori		\
-			|| x == vmi::lti		\
-			|| x == vmi::ltei		\
-			|| x == vmi::gti		\
-			|| x == vmi::gtei		\
-			|| x == vmi::cmpi		\
-			|| x == vmi::ncmpi		\
-			|| x == vmi::flti		\
-			|| x == vmi::fltei		\
-			|| x == vmi::fgti		\
-			|| x == vmi::fgtei		\
-			|| x == vmi::fcmpi		\
-			|| x == vmi::fncmpi		\
 		)
 
 	// the rest
@@ -120,10 +140,32 @@ namespace gjs {
 			|| x == vmi::subu		\
 			|| x == vmi::mulu		\
 			|| x == vmi::divu		\
+			|| x == vmi::lt			\
+			|| x == vmi::lte		\
+			|| x == vmi::gt			\
+			|| x == vmi::gte		\
+			|| x == vmi::cmp		\
+			|| x == vmi::ncmp		\
 			|| x == vmi::fadd		\
 			|| x == vmi::fsub		\
 			|| x == vmi::fmul		\
 			|| x == vmi::fdiv		\
+			|| x == vmi::flt		\
+			|| x == vmi::flte		\
+			|| x == vmi::fgt		\
+			|| x == vmi::fgte		\
+			|| x == vmi::fcmp		\
+			|| x == vmi::fncmp		\
+			|| x == vmi::dadd		\
+			|| x == vmi::dsub		\
+			|| x == vmi::dmul		\
+			|| x == vmi::ddiv		\
+			|| x == vmi::dlt		\
+			|| x == vmi::dlte		\
+			|| x == vmi::dgt		\
+			|| x == vmi::dgte		\
+			|| x == vmi::dcmp		\
+			|| x == vmi::dncmp		\
 			|| x == vmi::and		\
 			|| x == vmi::or			\
 			|| x == vmi::band		\
@@ -131,18 +173,6 @@ namespace gjs {
 			|| x == vmi::xor		\
 			|| x == vmi::sl			\
 			|| x == vmi::sr			\
-			|| x == vmi::lt			\
-			|| x == vmi::lte		\
-			|| x == vmi::gt			\
-			|| x == vmi::gte		\
-			|| x == vmi::cmp		\
-			|| x == vmi::ncmp		\
-			|| x == vmi::flt		\
-			|| x == vmi::flte		\
-			|| x == vmi::fgt		\
-			|| x == vmi::fgte		\
-			|| x == vmi::fcmp		\
-			|| x == vmi::fncmp		\
 		)
 
 	#define first_operand_is_register(x) \
@@ -180,8 +210,6 @@ namespace gjs {
 	#define first_operand_must_be_fpr(x) \
 		(								 \
 			   x == vmi::mffp			 \
-			|| x == vmi::ctf			 \
-			|| x == vmi::cti			 \
 			|| x == vmi::fadd			 \
 			|| x == vmi::fsub			 \
 			|| x == vmi::fmul			 \
@@ -192,6 +220,54 @@ namespace gjs {
 			|| x == vmi::fmuli			 \
 			|| x == vmi::fdivi			 \
 			|| x == vmi::fdivir			 \
+			|| x == vmi::flti			  \
+			|| x == vmi::fltei			  \
+			|| x == vmi::fgti			  \
+			|| x == vmi::fgtei			  \
+			|| x == vmi::fcmpi			  \
+			|| x == vmi::fncmpi			  \
+			|| x == vmi::dadd			  \
+			|| x == vmi::dsub			  \
+			|| x == vmi::dmul			  \
+			|| x == vmi::ddiv			  \
+			|| x == vmi::daddi			  \
+			|| x == vmi::dsubi			  \
+			|| x == vmi::dsubir			  \
+			|| x == vmi::dmuli			  \
+			|| x == vmi::ddivi			  \
+			|| x == vmi::ddivir			  \
+			|| x == vmi::dncmpi			  \
+			|| x == vmi::dlti			  \
+			|| x == vmi::dltei			  \
+			|| x == vmi::dgti			  \
+			|| x == vmi::dgtei			  \
+			|| x == vmi::dcmpi			  \
+			|| x == vmi::dncmpi			  \
+		)
+
+	// push, pop, cvt_*
+	#define first_operand_can_be_fpr(x)	\
+		(								\
+		       x == vmi::ld8			\
+			|| x == vmi::ld16			\
+			|| x == vmi::ld32			\
+			|| x == vmi::ld64			\
+			|| x == vmi::st8			\
+			|| x == vmi::st16			\
+			|| x == vmi::st32			\
+			|| x == vmi::st64			\
+			|| x == vmi::cvt_if			\
+			|| x == vmi::cvt_id			\
+			|| x == vmi::cvt_uf			\
+			|| x == vmi::cvt_ud			\
+			|| x == vmi::cvt_fi			\
+			|| x == vmi::cvt_fu			\
+			|| x == vmi::cvt_fd			\
+			|| x == vmi::cvt_di			\
+			|| x == vmi::cvt_du			\
+			|| x == vmi::cvt_df			\
+			|| x == vmi::push			\
+			|| x == vmi::pop			\
 		)
 	
 	#define second_operand_must_be_fpr(x) \
@@ -219,6 +295,28 @@ namespace gjs {
 			|| x == vmi::fgte			  \
 			|| x == vmi::fcmp			  \
 			|| x == vmi::fncmp			  \
+			|| x == vmi::dadd			  \
+			|| x == vmi::dsub			  \
+			|| x == vmi::dmul			  \
+			|| x == vmi::ddiv			  \
+			|| x == vmi::daddi			  \
+			|| x == vmi::dsubi			  \
+			|| x == vmi::dsubir			  \
+			|| x == vmi::dmuli			  \
+			|| x == vmi::ddivi			  \
+			|| x == vmi::ddivir			  \
+			|| x == vmi::dlti			  \
+			|| x == vmi::dltei			  \
+			|| x == vmi::dgti			  \
+			|| x == vmi::dgtei			  \
+			|| x == vmi::dcmpi			  \
+			|| x == vmi::dncmpi			  \
+			|| x == vmi::dlt			  \
+			|| x == vmi::dlte			  \
+			|| x == vmi::dgt			  \
+			|| x == vmi::dgte			  \
+			|| x == vmi::dcmp			  \
+			|| x == vmi::dncmp			  \
 		)
 	
 	#define third_operand_must_be_fpr(x)  \
@@ -227,13 +325,22 @@ namespace gjs {
 			|| x == vmi::fsub			  \
 			|| x == vmi::fmul			  \
 			|| x == vmi::fdiv			  \
-			|| x == vmi::fncmpi			  \
 			|| x == vmi::flt			  \
 			|| x == vmi::flte			  \
 			|| x == vmi::fgt			  \
 			|| x == vmi::fgte			  \
 			|| x == vmi::fcmp			  \
 			|| x == vmi::fncmp			  \
+			|| x == vmi::dadd			  \
+			|| x == vmi::dsub			  \
+			|| x == vmi::dmul			  \
+			|| x == vmi::ddiv			  \
+			|| x == vmi::dlt			  \
+			|| x == vmi::dlte			  \
+			|| x == vmi::dgt			  \
+			|| x == vmi::dgte			  \
+			|| x == vmi::dcmp			  \
+			|| x == vmi::dncmp			  \
 		)
 	
 	#define third_operand_must_be_fpi(x) \
@@ -250,6 +357,19 @@ namespace gjs {
 			|| x == vmi::fgtei			 \
 			|| x == vmi::fcmpi			 \
 			|| x == vmi::fncmpi			 \
+			|| x == vmi::daddi			 \
+			|| x == vmi::dsubi			 \
+			|| x == vmi::dsubir			 \
+			|| x == vmi::dmuli			 \
+			|| x == vmi::ddivi			 \
+			|| x == vmi::ddivir			 \
+			|| x == vmi::dncmpi			 \
+			|| x == vmi::dlti			 \
+			|| x == vmi::dltei			 \
+			|| x == vmi::dgti			 \
+			|| x == vmi::dgtei			 \
+			|| x == vmi::dcmpi			 \
+			|| x == vmi::dncmpi			 \
 		)
 
 	#define is_fpr(x) (x >= vmr::f0 && x <= vmr::f15)
@@ -330,7 +450,7 @@ namespace gjs {
 			return *this;
 		}
 
-		if (first_operand_must_be_fpr(instr) != is_fpr(reg) && !(check_instr_type_5(instr) && is_fpr(reg))) {
+		if (first_operand_must_be_fpr(instr) != is_fpr(reg) && !(first_operand_can_be_fpr(instr) && is_fpr(reg))) {
 			// insnstruction requires operand 1 to be floating point register
 			// exception
 			return *this;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,9 +27,9 @@ class foo {
 		i32 y;
 		i32 z;
 		f32 w;
-		static f64 s;
+		static f32 s;
 };
-f64 foo::s = 5.5;
+f32 foo::s = 5.5;
 
 struct vec3 { f32 x, y, z; };
 void testvec(void* vec) {

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -830,8 +830,13 @@ namespace gjs {
 			ast_node* node = new ast_node();
 			node->type = ast_node::node_type::constant;
 			if (tok.text.find_first_of('.') != string::npos) {
-				node->c_type = ast_node::constant_type::decimal;
-				node->value.d =	atof(tok.text.c_str());
+				if (tok.text[tok.text.length() - 1] == 'f') {
+					node->c_type = ast_node::constant_type::f32;
+					node->value.f_32 = atof(tok.text.c_str());
+				} else {
+					node->c_type = ast_node::constant_type::f64;
+					node->value.f_64 = atof(tok.text.c_str());
+				}
 			} else {
 				node->c_type = ast_node::constant_type::integer;
 				node->value.i =	atoi(tok.text.c_str());
@@ -1017,7 +1022,8 @@ namespace gjs {
 
 		switch(c_type) {
 			case constant_type::integer: { tab(indent); printf("value: %lld,\n", value.i); break; }
-			case constant_type::decimal: { tab(indent); printf("value: %f,\n", value.d); break; }
+			case constant_type::f32: { tab(indent); printf("value: %f,\n", value.f_32); break; }
+			case constant_type::f64: { tab(indent); printf("value: %f,\n", value.f_64); break; }
 			case constant_type::string: { tab(indent); printf("value: '%s',\n", value.s); break; }
 			default: break;
 		}

--- a/src/parse.h
+++ b/src/parse.h
@@ -38,7 +38,8 @@ namespace gjs {
 		enum class constant_type {
 			none,
 			integer,
-			decimal,
+			f32,
+			f64,
 			string
 		};
 		enum class operation_type {
@@ -123,16 +124,19 @@ namespace gjs {
 		constant_type c_type;
 		union {
 			i64 i;
-			double d;
+			f32 f_32;
+			f64 f_64;
 			char* s;
 		} value;
 
-		inline void set(i64 v) { value.i = v; }
-		inline void set(double v) { value.d = v; }
+		inline void set(i64 v) { value.i = v; c_type = constant_type::integer; }
+		inline void set(f32 v) { value.f_32 = v; c_type = constant_type::f32; }
+		inline void set(f64 v) { value.f_64 = v; c_type = constant_type::f64; }
 		inline void set(const std::string& v) {
 			value.s = new char[v.length() + 1];
 			memset(value.s, 0, v.length() + 1);
 			snprintf(value.s, v.length() + 1, "%s", v.c_str());
+			c_type = constant_type::string;
 		}
 		inline void src(const tokenizer& t, const tokenizer::token& tk) {
 			start.lineText = t.lines[tk.line];
@@ -143,7 +147,8 @@ namespace gjs {
 
 		operator std::string() const { return value.s; }
 		operator i64() { return value.i; }
-		operator double() { return value.d; }
+		operator f32() { return value.f_32; }
+		operator f64() { return value.f_64; }
 
 		// per-type values
 		operation_type op;

--- a/src/parse_utils.cpp
+++ b/src/parse_utils.cpp
@@ -64,6 +64,7 @@ namespace gjs {
 				decimal_found = true;
 				continue;
 			}
+			if (thing[idx] == 'f' && idx == thing.length() - 1) continue;
 			if (thing[idx] < 48 || thing[idx] > 57) return false;
 		}
 
@@ -772,6 +773,7 @@ namespace gjs {
 
 		bool isNeg = false;
 		bool hasDecimal = false;
+		bool is_f32 = false;
 		size_t offset = 0;
 
 		while (!at_end()) {
@@ -796,6 +798,10 @@ namespace gjs {
 				out.text += c;
 				offset++;
 			} else if (c >= 48 && c <= 57) {
+				out.text += c;
+				offset++;
+			} else if (c == 'f' && !is_f32) {
+				is_f32 = true;
 				out.text += c;
 				offset++;
 			} else {


### PR DESCRIPTION
- Floating point literals can now have `f` appended to indicate they should be of type `f32` rather than `f64`
- Duplicated `f*` instructions with the same name but with the `d` prefix instead of `f` for `f64` based operations
- Made `f*` instructions `f32` based instead of `f64` based
- Improved `cast` function behavior
- Added more built-in type conversion instructions, renamed to the format `cvt.<from>.<to>`
- Removed `'(must be fp register)'` from conversion instruction descriptions (since they don't have to be)
- Fixed some instruction type checks in `instruction_encoder.cpp`
- Probably more