### PR TITLE
Assignment fixes and other fixes

### DIFF
--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -7,6 +7,15 @@ void it() {
     f.x = 5;
     f.x += 5;
     if (x.length > 0) {
+        print_foo(f);
         x.push(5.55f);
+    }
+
+    for(u8 i = 0;i < 10;i++) {
+        x.push(i);
+    }
+
+    for(u8 i = 0;i < x.length;i++) {
+        print_f32(i, x[i]);
     }
 }

--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -1,6 +1,11 @@
-
 void it() {
     array<f32> x;
     x.push(1.23f);
     x.push(x[0]);
+    foo f;
+    f.x = 5;
+    f.x += 5;
+    if (x.length > 0) {
+        x.push(5.55f);
+    }
 }

--- a/bin/test.gjs
+++ b/bin/test.gjs
@@ -2,6 +2,7 @@ void it() {
     array<f32> x;
     x.push(1.23f);
     x.push(x[0]);
+    x[0] = 4.56f;
     foo f;
     f.x = 5;
     f.x += 5;

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -104,6 +104,7 @@ namespace gjs {
 		arr.constructor<vm_type*>();
 		arr.method("push", &script_array::push);
 		arr.method("operator []", &script_array::operator[]);
+		arr.prop(std::string("length"), &script_array::length, bind::property_flags::pf_read_only);
 		tp = arr.finalize();
 		tp->requires_subtype = true;
 		tp->is_builtin = true;
@@ -146,5 +147,9 @@ namespace gjs {
 
 	subtype_t* script_array::operator[](u32 idx) {
 		return (subtype_t*)(m_data + (idx * m_type->size));
+	}
+
+	u32 script_array::length() {
+		return m_count;
 	}
 };

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -141,12 +141,15 @@ namespace gjs {
 			m_data = new u8[32 * m_type->size];
 			m_capacity = 32;
 		}
+		f32 t = *(f32*)&elem->data;
 		memcpy(m_data + (m_count * m_type->size), &elem->data, m_type->size);
 		m_count++;
 	}
 
 	subtype_t* script_array::operator[](u32 idx) {
-		return (subtype_t*)(m_data + (idx * m_type->size));
+		subtype_t* o = (subtype_t*)(m_data + (idx * m_type->size));
+		f32 t = *(f32*)&o->data;
+		return o;
 	}
 
 	u32 script_array::length() {

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -20,6 +20,7 @@ namespace gjs {
 
 			void push(subtype_t* elem);
 			subtype_t* operator[](u32 idx);
+			u32 length();
 
 		protected:
 			u64 m_size;

--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -447,6 +447,7 @@ namespace gjs {
 
 	void init_context(compile_context& ctx) {
 		ctx.do_store_member_info = false;
+		ctx.last_member_or_method.subject = nullptr;
 		ctx.clear_last_member_info();
 		ctx.cur_func = nullptr;
 		data_type* t = nullptr;

--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -446,10 +446,9 @@ namespace gjs {
 	}
 
 	void init_context(compile_context& ctx) {
-		ctx.do_store_member_pointer = false;
-		ctx.last_member_was_pointer = false;
+		ctx.do_store_member_info = false;
+		ctx.clear_last_member_info();
 		ctx.cur_func = nullptr;
-		ctx.last_type_method = nullptr;
 		data_type* t = nullptr;
 
 		vector<vm_type*> types = ctx.ctx->types()->all();

--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -118,13 +118,14 @@ namespace gjs {
 		ctx.cur_func = nullptr;
 	}
 
-	void compile_variable_declaration(compile_context& ctx, ast_node* node) {
+	var* compile_variable_declaration(compile_context& ctx, ast_node* node) {
 		if (node->initializer) {
 			var* v = ctx.cur_func->allocate(ctx, node);
 			v->total_ref_count = count_references(ctx.cur_func->root, v->name);
 			v->no_auto_free = true;
 			compile_expression(ctx, node->initializer->body, v);
 			v->no_auto_free = false;
+			return v;
 		} else {
 			data_type* tp = ctx.type(node->data_type);
 			if (tp->ctor) {
@@ -143,12 +144,15 @@ namespace gjs {
 						obj->move_stack_reference(ret);
 
 						for (u32 i = 0;i < args.size();i++) ctx.cur_func->free(args[i]);
+
+						return ret;
 					} else {
 						ctx.log->err(format("Type '%s' can not be constructed without a sub-type", tp->name.c_str()), node);
 
 						// Prevent errors that would stem from this
 						var* v = ctx.cur_func->allocate(ctx, node);
 						v->total_ref_count = count_references(ctx.cur_func->root, v->name);
+						return v;
 					}
 				} else {
 					var* obj = ctx.cur_func->allocate_stack_var(ctx, tp, node);
@@ -160,10 +164,12 @@ namespace gjs {
 					ret->total_ref_count = count_references(ctx.cur_func->root, ret->name);
 					obj->move_stack_reference(ret);
 					ctx.cur_func->free(obj);
+					return ret;
 				}
 			} else {
 				var* v = ctx.cur_func->allocate(ctx, node);
 				v->total_ref_count = count_references(ctx.cur_func->root, v->name);
+				return v;
 			}
 		}
 	}
@@ -223,9 +229,14 @@ namespace gjs {
 
 	void compile_for_loop(compile_context& ctx, ast_node* node) {
 		ctx.cur_func->push_scope();
-		ctx.cur_func->auto_free_consumed_vars = false;
 		
-		if (node->initializer) compile_variable_declaration(ctx, node->initializer);
+		if (node->initializer) {
+			compile_variable_declaration(ctx, node->initializer);
+
+			// variables declared inside for loop statement should be alone in their scope
+			// (to prevent them from being freed during the scope of the body)
+			ctx.cur_func->push_scope();
+		}
 		address loop_cond = ctx.out->size();
 		address branch_addr = 0;
 		if (node->condition) {
@@ -238,15 +249,15 @@ namespace gjs {
 			ctx.cur_func->free(cond);
 		}
 
-		if (node->modifier) {
-			var* mod = compile_expression(ctx, node->modifier, nullptr);
-			ctx.cur_func->free(mod);
-		}
-
 		ast_node* n = node->body;
 		while (n) {
 			compile_node(ctx, n);
 			n = n->next;
+		}
+
+		if (node->modifier) {
+			var* mod = compile_expression(ctx, node->modifier, nullptr);
+			ctx.cur_func->free(mod);
 		}
 
 		ctx.add(
@@ -262,8 +273,7 @@ namespace gjs {
 				encode(branch.instr()).operand(branch.op_1r()).operand(ctx.out->size())
 			);
 		}
-
-		ctx.cur_func->auto_free_consumed_vars = true;
+		if (node->initializer) ctx.cur_func->pop_scope(ctx, node);
 		ctx.cur_func->pop_scope(ctx, node);
 	}
 

--- a/src/compiler/context.cpp
+++ b/src/compiler/context.cpp
@@ -10,6 +10,15 @@
 using namespace std;
 
 namespace gjs {
+	void compile_context::clear_last_member_info() {
+		do_store_member_info = false;
+		last_member_or_method.is_set = false;
+		last_member_or_method.name = "";
+		last_member_or_method.subject = nullptr;
+		last_member_or_method.type = nullptr;
+		last_member_or_method.method = nullptr;
+	}
+
 	void compile_context::add(instruction& i, ast_node* because) {
 		address addr = out->size();
 		(*out) += i;

--- a/src/compiler/context.cpp
+++ b/src/compiler/context.cpp
@@ -1,6 +1,7 @@
 #include <compiler/context.h>
 #include <compiler/function.h>
 #include <compiler/data_type.h>
+#include <compiler/variable.h>
 
 #include <instruction_array.h>
 #include <compile_log.h>
@@ -11,6 +12,7 @@ using namespace std;
 
 namespace gjs {
 	void compile_context::clear_last_member_info() {
+		if (last_member_or_method.subject) last_member_or_method.subject->no_auto_free = false;
 		do_store_member_info = false;
 		last_member_or_method.is_set = false;
 		last_member_or_method.name = "";

--- a/src/compiler/context.h
+++ b/src/compiler/context.h
@@ -8,6 +8,7 @@ namespace gjs {
 	class instruction_array;
 	class source_map;
 	class vm_context;
+	enum class vm_register;
 	struct func;
 	struct ast_node;
 	struct data_type;
@@ -33,6 +34,10 @@ namespace gjs {
 		} last_member_or_method;
 
 		void clear_last_member_info();
+
+		bool do_store_func_return_ptr;
+		bool did_store_func_return_ptr;
+		vm_register func_return_ptr_loc;
 
 		void add(instruction& i, ast_node* because);
 

--- a/src/compiler/context.h
+++ b/src/compiler/context.h
@@ -11,6 +11,7 @@ namespace gjs {
 	struct func;
 	struct ast_node;
 	struct data_type;
+	struct var;
 
 	struct compile_context {
 		vm_context* ctx;
@@ -22,11 +23,16 @@ namespace gjs {
 		std::vector<func*> funcs;
 
 		// used when compiling expressions involving type properties
-		bool do_store_member_pointer;
-		bool last_member_was_pointer;
+		bool do_store_member_info;
+		struct {
+			bool is_set;
+			std::string name;
+			data_type* type;
+			var* subject;
+			func* method;
+		} last_member_or_method;
 
-		// used when compiling expressions involving type methods
-		func* last_type_method;
+		void clear_last_member_info();
 
 		void add(instruction& i, ast_node* because);
 

--- a/src/compiler/function.cpp
+++ b/src/compiler/function.cpp
@@ -516,6 +516,15 @@ namespace gjs {
 						case 8: { ld = vmi::ld64; break; }
 					}
 
+					if (ctx.do_store_func_return_ptr) {
+						ctx.add(
+							encode(vmi::addui).operand(vmr::v1).operand(to->return_loc),
+							because
+						);
+						ctx.did_store_func_return_ptr = true;
+						ctx.func_return_ptr_loc = vmr::v1;
+					}
+
 					ctx.add(
 						encode(ld).operand(ret->loc.reg).operand(to->return_loc),
 						because
@@ -526,6 +535,8 @@ namespace gjs {
 						encode(vmi::add).operand(ret->loc.reg).operand(to->return_loc).operand(vmr::zero),
 						because
 					);
+					ctx.did_store_func_return_ptr = true;
+					ctx.func_return_ptr_loc = ret->loc.reg;
 				}
 			} else {
 				// if it's not a pointer, it is either a primitive type or an unsupported host stack return
@@ -654,6 +665,8 @@ namespace gjs {
 		}
 
 		// store return value if necessary
+		ctx.did_store_func_return_ptr = false;
+		ctx.func_return_ptr_loc = vmr::register_count;
 		if (ret) {
 			data_type* ret_tp = to->return_type;
 			if (to->return_type->name == "__subtype__") ret_tp = method_of->sub_type;

--- a/src/compiler/function.cpp
+++ b/src/compiler/function.cpp
@@ -531,13 +531,19 @@ namespace gjs {
 				// if it's not a pointer, it is either a primitive type or an unsupported host stack return
 				if (ret->loc.reg != to->return_loc) {
 					if (!is_fp(ret->loc.reg)) {
+						vmi assign = vmi::add;
+						if (ret->type->is_unsigned) assign = vmi::addu;
+
 						ctx.add(
-							encode(vmi::add).operand(ret->loc.reg).operand(to->return_loc).operand(vmr::zero),
+							encode(assign).operand(ret->loc.reg).operand(to->return_loc).operand(vmr::zero),
 							because
 						);
 					} else {
+						vmi assign = vmi::fadd;
+						if (ret->type->size == sizeof(f64)) assign = vmi::dadd;
+
 						ctx.add(
-							encode(vmi::fadd).operand(ret->loc.reg).operand(to->return_loc).operand(vmr::zero),
+							encode(assign).operand(ret->loc.reg).operand(to->return_loc).operand(vmr::zero),
 							because
 						);
 					}

--- a/src/compiler/function.h
+++ b/src/compiler/function.h
@@ -100,6 +100,6 @@ namespace gjs {
 	};
 
 	void compile_function(compile_context& ctx, ast_node* node, func* out);
-	void compile_variable_declaration(compile_context& ctx, ast_node* node);
+	var* compile_variable_declaration(compile_context& ctx, ast_node* node);
 	var* call(compile_context& ctx, func* to, ast_node* because, const std::vector<var*>& args, data_type* method_of = nullptr);
 };

--- a/src/instruction_encoder.cpp
+++ b/src/instruction_encoder.cpp
@@ -588,7 +588,7 @@ namespace gjs {
 				std::string reg_val = ""; // "<" + state->registers[(integer)r].to_string() + ">"
 
 				if (is_fpr(r)) reg_val = format("<%f>", *(f32*)&state->registers[(integer)r]);
-				else reg_val = format("<%d>", *(i32*)&state->registers[(integer)r]);
+				else reg_val = format("<%lld>", *(i64*)&state->registers[(integer)r]);
 				return "$" + std::string(register_str[(integer)r]) + reg_val;
 			}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ using namespace gjs;
 
 class foo {
 	public:
-		foo() : y(0), z(0), w(0.0f) {
+		foo() : x(0), y(0), z(0), w(0.0f) {
 			printf("Construct foo\n");
 		}
 		~foo() {
@@ -34,6 +34,7 @@ class foo {
 		i32 set_x(i32 _x) {
 			return x = _x;
 		}
+
 		i32 x;
 		i32 y;
 		i32 z;
@@ -54,7 +55,11 @@ void dtestvec(void* vec) {
 }
 
 void print_foo(const foo& f) {
-	printf("foo: %d, %d, %f\n", f.y, f.z, f.w);
+	printf("foo: %d, %d, %d, %f\n", f.x, f.y, f.z, f.w);
+}
+
+void print_f32(u8 i, f32 f) {
+	printf("%d: %f\n", i, f);
 }
 
 void print_log(vm_context& ctx) {
@@ -165,6 +170,7 @@ int main(int arg_count, const char** args) {
 		ctx.bind(print_foo, "print_foo");
 		ctx.bind(testvec, "testvec");
 		ctx.bind(dtestvec, "dtestvec");
+		ctx.bind(print_f32, "print_f32");
 	} catch (bind_exception& e) {
 		printf("%s\n", e.text.c_str());
 	}
@@ -175,10 +181,10 @@ int main(int arg_count, const char** args) {
 		return 1;
 	}
 	print_log(ctx);
-	print_code(ctx);
+	//print_code(ctx);
 
 	printf("-------------result-------------\n");
-	ctx.log_instructions(true);
+	//ctx.log_instructions(true);
 	ctx.function("it");
 	vm_function* func = ctx.function("it");
 	if (func) func->call<void*>(nullptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,13 @@ class foo {
 
 		operator i32() { return y; }
 
+		i32 get_x() {
+			return x;
+		}
+		i32 set_x(i32 _x) {
+			return x = _x;
+		}
+		i32 x;
 		i32 y;
 		i32 z;
 		f32 w;
@@ -148,6 +155,7 @@ int main(int arg_count, const char** args) {
 		f.method("ft", &foo::ft);
 		f.method("operator i32", &foo::operator i32);
 		f.method("static_func", &foo::static_func);
+		f.prop("x", &foo::get_x, &foo::set_x, bind::property_flags::pf_none);
 		f.prop("y", &foo::y, bind::property_flags::pf_none);
 		f.prop("z", &foo::z, bind::property_flags::pf_none);
 		f.prop("w", &foo::w, bind::property_flags::pf_none);

--- a/src/parse_utils.cpp
+++ b/src/parse_utils.cpp
@@ -178,7 +178,7 @@ namespace gjs {
 		}
 
 
-		while(!at_end()) {
+		while(!at_end(false)) {
 			if (whitespace()) break;
 			c = m_input[m_idx];
 			if (out.text.length() > 0 && (c == '(' || c == ')')) break;

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -856,6 +856,10 @@ namespace gjs {
 		void* ret_addr = nullptr;
 		if (f->signature.return_type->size > 0) {
 			ret_addr = &(m_ctx->state()->registers[(u8)f->signature.return_loc]);
+
+			// make sure there are no left over bits or bytes from the previous value
+			(*(u64*)ret_addr) = 0;
+
 			if (f->signature.returns_on_stack) {
 				u64 return_value_end = u64(ret_addr) + f->signature.return_type->size;
 				u64 stack_end = (u64)state.memory[0] + m_stack_size;


### PR DESCRIPTION
- Fixed variable assignments
- Implemented property getters/setters
- Allow assignment to index operator result if index operator returns a pointer type
- Fixed for loop logic (was incrementing post-condition instead of post-loop body)
- auto-var-free now only frees vars in the current scope
- For loop statement declaration (`for(decl;...;...)`) now has its own scope (to prevent the auto-free from freeing the variable)
- Reimplemented register var restoration after function calls (required for loops unless all loop types can somehow be compiled to `do...while` loops)